### PR TITLE
Bugfix: concurrent map writes

### DIFF
--- a/charts/oceanbase-cluster/templates/NOTES.txt
+++ b/charts/oceanbase-cluster/templates/NOTES.txt
@@ -1,6 +1,6 @@
 Welcome to OceanBase Cluster! 
 
-After installing OBCluster chart, you need to wait for the cluster bootstrapped. Bootstrap progress will cost approximately 2~3 minutes which may varies depends on the machine.
+After installing OBCluster chart, you need to wait for the cluster bootstrapped. Bootstrap progress will cost approximately 2~3 minutes which may vary depends on the machine.
 
 You can use the following command to wait for the OBCluster to be ready.
 

--- a/charts/oceanbase-cluster/templates/secret.yaml
+++ b/charts/oceanbase-cluster/templates/secret.yaml
@@ -1,6 +1,5 @@
 {{- if $.Values.generateUserSecrets }}
   {{- range $secretName := $.Values.userSecrets }}
-    {{- if empty (lookup "v1" "Secret" $.Release.Namespace $secretName) }}
 --- # the lookup function will return an empty list when dry-running or local rendering
 apiVersion: v1
 kind: Secret
@@ -10,7 +9,10 @@ metadata:
   labels:
   {{- include "oceanbase-cluster.labels" $ | nindent 4 }}
 data:
+    {{- if empty (lookup "v1" "Secret" $.Release.Namespace $secretName) }}
   password: {{ randAlphaNum 16 | b64enc }}
+    {{- else }}
+  password: {{ (lookup "v1" "Secret" $.Release.Namespace $secretName).data.password }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/pkg/controller/observer_controller.go
+++ b/pkg/controller/observer_controller.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1alpha1 "github.com/oceanbase/ob-operator/api/v1alpha1"
@@ -114,7 +113,6 @@ func (r *OBServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 func (r *OBServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.OBServer{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 9}).
 		WithEventFilter(preds).
 		Complete(r)
 }

--- a/pkg/resource/globalWhiteList.go
+++ b/pkg/resource/globalWhiteList.go
@@ -1,0 +1,17 @@
+/*
+Copyright (c) 2023 OceanBase
+ob-operator is licensed under Mulan PSL v2.
+You can use this software according to the terms and conditions of the Mulan PSL v2.
+You may obtain a copy of Mulan PSL v2 at:
+         http://license.coscl.org.cn/MulanPSL2
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+See the Mulan PSL v2 for more details.
+*/
+
+package resource
+
+import "sync"
+
+var GlobalWhiteListMap sync.Map

--- a/pkg/resource/obtenant_manager.go
+++ b/pkg/resource/obtenant_manager.go
@@ -565,12 +565,12 @@ func (m *OBTenantManager) buildTenantStatus() (*v1alpha1.OBTenantStatus, error) 
 	tenantCurrentStatus.TenantRecordInfo.TenantID = int(obtenant.TenantID)
 
 	// TODO: get whitelist from tenant account
-	whitelist, exists := GlobalWhiteListMap.Load(obtenant.TenantName)
+	whitelist, exists := tenantWhiteListMap.Load(obtenant.TenantName)
 	if exists {
 		tenantCurrentStatus.TenantRecordInfo.ConnectWhiteList = whitelist.(string)
 	} else {
 		// try update whitelist after the manager restart
-		GlobalWhiteListMap.Store(obtenant.TenantName, tenant.DefaultOBTcpInvitedNodes)
+		tenantWhiteListMap.Store(obtenant.TenantName, tenant.DefaultOBTcpInvitedNodes)
 		tenantCurrentStatus.TenantRecordInfo.ConnectWhiteList = tenant.DefaultOBTcpInvitedNodes
 	}
 

--- a/pkg/resource/obtenant_task.go
+++ b/pkg/resource/obtenant_task.go
@@ -226,7 +226,7 @@ func (m *OBTenantManager) CheckAndApplyWhiteList() error {
 		}
 		// TODO: get whitelist variable by tenant account
 		// Because getting a whitelist requires specifying a tenant , temporary use .Status.TenantRecordInfo.ConnectWhiteList as value in db
-		GlobalWhiteListMap.Store(tenantName, specWhiteList)
+		tenantWhiteListMap.Store(tenantName, specWhiteList)
 	}
 	return nil
 }
@@ -389,7 +389,7 @@ func (m *OBTenantManager) createTenant() error {
 		m.Recorder.Event(m.OBTenant, corev1.EventTypeWarning, "failed to create OBTenant", err.Error())
 		return err
 	}
-	GlobalWhiteListMap.Store(tenantName, m.OBTenant.Spec.ConnectWhiteList)
+	tenantWhiteListMap.Store(tenantName, m.OBTenant.Spec.ConnectWhiteList)
 	// Create user or change password of root, do not return error
 	m.Recorder.Event(m.OBTenant, "Create", "", "create OBTenant successfully")
 	return nil

--- a/pkg/resource/obtenant_task.go
+++ b/pkg/resource/obtenant_task.go
@@ -224,9 +224,9 @@ func (m *OBTenantManager) CheckAndApplyWhiteList() error {
 		if err != nil {
 			return err
 		}
-		// TODO get whitelist variable by tenant account
+		// TODO: get whitelist variable by tenant account
 		// Because getting a whitelist requires specifying a tenant , temporary use .Status.TenantRecordInfo.ConnectWhiteList as value in db
-		GlobalWhiteListMap[tenantName] = specWhiteList
+		GlobalWhiteListMap.Store(tenantName, specWhiteList)
 	}
 	return nil
 }
@@ -389,7 +389,7 @@ func (m *OBTenantManager) createTenant() error {
 		m.Recorder.Event(m.OBTenant, corev1.EventTypeWarning, "failed to create OBTenant", err.Error())
 		return err
 	}
-	GlobalWhiteListMap[tenantName] = m.OBTenant.Spec.ConnectWhiteList
+	GlobalWhiteListMap.Store(tenantName, m.OBTenant.Spec.ConnectWhiteList)
 	// Create user or change password of root, do not return error
 	m.Recorder.Event(m.OBTenant, "Create", "", "create OBTenant successfully")
 	return nil

--- a/pkg/resource/obtenantrestore_task.go
+++ b/pkg/resource/obtenantrestore_task.go
@@ -117,7 +117,7 @@ func (m *OBTenantManager) WatchRestoreJobToFinish() error {
 		}
 		time.Sleep(5 * time.Second)
 	}
-	GlobalWhiteListMap.Store(m.OBTenant.Spec.TenantName, m.OBTenant.Spec.ConnectWhiteList)
+	tenantWhiteListMap.Store(m.OBTenant.Spec.TenantName, m.OBTenant.Spec.ConnectWhiteList)
 	m.Recorder.Event(m.OBTenant, "RestoreJobFinished", "", "restore job finished successfully")
 	return nil
 }

--- a/pkg/resource/obtenantrestore_task.go
+++ b/pkg/resource/obtenantrestore_task.go
@@ -117,7 +117,7 @@ func (m *OBTenantManager) WatchRestoreJobToFinish() error {
 		}
 		time.Sleep(5 * time.Second)
 	}
-	GlobalWhiteListMap[m.OBTenant.Spec.TenantName] = m.OBTenant.Spec.ConnectWhiteList
+	GlobalWhiteListMap.Store(m.OBTenant.Spec.TenantName, m.OBTenant.Spec.ConnectWhiteList)
 	m.Recorder.Event(m.OBTenant, "RestoreJobFinished", "", "restore job finished successfully")
 	return nil
 }

--- a/pkg/resource/tenantWhiteList.go
+++ b/pkg/resource/tenantWhiteList.go
@@ -14,4 +14,4 @@ package resource
 
 import "sync"
 
-var GlobalWhiteListMap sync.Map
+var tenantWhiteListMap sync.Map

--- a/pkg/task/task_manager.go
+++ b/pkg/task/task_manager.go
@@ -52,7 +52,6 @@ type TaskManager struct {
 func (m *TaskManager) Submit(f func() error) string {
 	retCh := make(chan *TaskResult, 1)
 	taskId := uuid.New().String()
-	// TODO add lock to keep ResultMap safe
 	m.ResultMap.Store(taskId, retCh)
 	m.TaskResultCache.Delete(taskId)
 	go func() {


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

* OBServer controller has 9 concurrent reconciles at most, so it's possible that two go routines reconcile observer at the same time. When the two (or more) go routines write the same key in task map in TaskManager which has no guarding Lock, program crashes.

## Solution Description
<!-- Please clearly and concisely describe your solution. -->

1. Change maps used in TaskManager from standard map to sync.Map, which is thread-safe.
2. Fix GlobalWhiteList used in OBTenantManager by the way.