### PR TITLE
Fix: annotations mask

### DIFF
--- a/pkg/controller/obcluster_controller.go
+++ b/pkg/controller/obcluster_controller.go
@@ -94,6 +94,7 @@ func (r *OBClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 func (r *OBClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.OBCluster{}).
+		Owns(&v1alpha1.OBZone{}).
 		WithEventFilter(preds).
 		Complete(r)
 }

--- a/pkg/controller/obzone_controller.go
+++ b/pkg/controller/obzone_controller.go
@@ -86,6 +86,7 @@ func (r *OBZoneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 func (r *OBZoneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.OBZone{}).
+		Owns(&v1alpha1.OBServer{}).
 		WithEventFilter(preds).
 		Complete(r)
 }

--- a/pkg/resource/coordinator.go
+++ b/pkg/resource/coordinator.go
@@ -26,9 +26,9 @@ import (
 )
 
 const (
-	// If no task flow, requeue after 60 sec.
+	// If no task flow, requeue after 30 sec.
 	NormalRequeueDuration = 30 * time.Second
-	// In task flow, requeue after 500 ms.
+	// In task flow, requeue after 1 sec.
 	ExecutionRequeueDuration = 1 * time.Second
 )
 

--- a/pkg/telemetry/sentry.go
+++ b/pkg/telemetry/sentry.go
@@ -33,6 +33,7 @@ func objectSentry(object any) {
 	if metaObj, ok := object.(metav1.Object); ok {
 		// remove managed fields which are of no interest
 		metaObj.SetManagedFields(nil)
+		metaObj.SetAnnotations(nil) // annotations may be privacy sensitive
 	}
 
 	if cluster, ok := object.(*v1alpha1.OBCluster); ok {


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

* Set annotations of object to nil, avoiding possible sensitive telemetry frame
* Make OBZone and OBCluster controller listen events of their owned resources. OBCluster controller listens events of OBZones, and OBCluster controller reacts when obzones change.