### PR TITLE
Fix not supported syntax in v4.2.1 and backup policy mismatch names of OBTenant resource

### DIFF
--- a/distribution/obproxy/start.sh
+++ b/distribution/obproxy/start.sh
@@ -12,10 +12,10 @@ fi
 
 if [ ! -z $CONFIG_URL ]; then
     echo "use config server"
-    cd /home/admin/obproxy && /home/admin/obproxy/bin/obproxy -p 2883 -n ${APP_NAME} -o observer_sys_password=${PROXYRO_PASSWORD_HASH},obproxy_config_server_url="${CONFIG_URL}",prometheus_sync_interval=1,prometheus_listen_port=2884,enable_metadb_used=false,skip_proxy_sys_private_check=true,log_dir_size_threshold=10G,enable_proxy_scramble=true,enable_strict_kernel_release=false --nodaemon
+    cd /home/admin/obproxy && /home/admin/obproxy/bin/obproxy -p 2883 -l 2884 -n ${APP_NAME} -o observer_sys_password=${PROXYRO_PASSWORD_HASH},obproxy_config_server_url="${CONFIG_URL}",prometheus_sync_interval=1,enable_metadb_used=false,skip_proxy_sys_private_check=true,log_dir_size_threshold=10G,enable_proxy_scramble=true,enable_strict_kernel_release=false --nodaemon
 elif [ ! -z $RS_LIST ]; then
     echo "use rslist"
-    cd /home/admin/obproxy && /home/admin/obproxy/bin/obproxy -p 2883 -n ${APP_NAME} -c ${OB_CLUSTER} -r\"${RS_LIST}\" -o observer_sys_password=${PROXYRO_PASSWORD_HASH},prometheus_sync_interval=1,prometheus_listen_port=2884,enable_metadb_used=false,skip_proxy_sys_private_check=true,log_dir_size_threshold=10G,enable_proxy_scramble=true,enable_strict_kernel_release=false --nodaemon
+    cd /home/admin/obproxy && /home/admin/obproxy/bin/obproxy -p 2883 -l 2884 -n ${APP_NAME} -c ${OB_CLUSTER} -r "${RS_LIST}" -o observer_sys_password=${PROXYRO_PASSWORD_HASH},prometheus_sync_interval=1,enable_metadb_used=false,skip_proxy_sys_private_check=true,log_dir_size_threshold=10G,enable_proxy_scramble=true,enable_strict_kernel_release=false --nodaemon
 else 
     echo "no config server or rs list"
     exit 1

--- a/pkg/oceanbase/const/sql/backup.go
+++ b/pkg/oceanbase/const/sql/backup.go
@@ -52,7 +52,8 @@ const (
 	QueryLatestBackupJobOfTypeAndPath        = "SELECT " + backupJobFields + " FROM DBA_OB_BACKUP_JOBS WHERE backup_type = ? and path = ? order by job_id DESC LIMIT 1"
 	QueryLatestBackupJobHistoryOfTypeAndPath = "SELECT " + backupJobFields + " FROM DBA_OB_BACKUP_JOB_HISTORY WHERE backup_type = ? and path = ? order by job_id DESC LIMIT 1"
 	QueryLatestRunningBackupJob              = "SELECT " + backupJobFields + " FROM DBA_OB_BACKUP_JOBS order by job_id DESC LIMIT 1"
-	QueryLatestCleanJob                      = "SELECT " + cleanJobFields + " FROM DBA_OB_BACKUP_DELETE_JOBS ORDER BY job_id DESC LIMIT 1 UNION ALL SELECT " + cleanJobFields + " FROM DBA_OB_BACKUP_DELETE_JOB_HISTORY ORDER BY job_id DESC LIMIT 1"
+	QueryLatestCleanJob                      = "SELECT " + cleanJobFields + " FROM DBA_OB_BACKUP_DELETE_JOBS ORDER BY job_id DESC LIMIT 1"
+	QueryLatestCleanJobHistory               = "SELECT " + cleanJobFields + " FROM DBA_OB_BACKUP_DELETE_JOB_HISTORY ORDER BY job_id DESC LIMIT 1"
 	QueryLatestArchiveLogJob                 = "SELECT " + logArchiveJobFields + " FROM DBA_OB_ARCHIVELOG_SUMMARY ORDER BY round_id DESC LIMIT 1"
 
 	QueryBackupJobWithId            = "SELECT " + backupJobFields + " FROM DBA_OB_BACKUP_JOBS WHERE job_id = ?"

--- a/pkg/oceanbase/operation/backup.go
+++ b/pkg/oceanbase/operation/backup.go
@@ -272,6 +272,13 @@ func (m *OceanbaseOperationManager) GetLatestBackupCleanJob() (*model.OBBackupCl
 	if len(jobs) != 0 {
 		return jobs[0], nil
 	}
+	err = m.QueryList(&jobs, sql.QueryLatestCleanJobHistory)
+	if err != nil {
+		return nil, err
+	}
+	if len(jobs) != 0 {
+		return jobs[0], nil
+	}
 	return nil, nil
 }
 

--- a/pkg/resource/obtenantbackuppolicy_manager.go
+++ b/pkg/resource/obtenantbackuppolicy_manager.go
@@ -128,7 +128,7 @@ func (m *ObTenantBackupPolicyManager) syncTenantInformation() error {
 	tenant := &v1alpha1.OBTenant{}
 	err := m.Client.Get(m.Ctx, types.NamespacedName{
 		Namespace: m.BackupPolicy.Namespace,
-		Name:      m.BackupPolicy.Spec.TenantName,
+		Name:      m.BackupPolicy.Spec.TenantCRName,
 	}, tenant)
 	if err != nil {
 		return err
@@ -393,15 +393,15 @@ func (m *ObTenantBackupPolicyManager) getOBTenantCR() (*v1alpha1.OBTenant, error
 			Resource: "obtenantbackuppolicies",
 		}, m.BackupPolicy.Spec.TenantCRName)
 	}
-	tenantName := m.BackupPolicy.Spec.TenantCRName
+	tenantCRName := m.BackupPolicy.Spec.TenantCRName
 	tenant := &v1alpha1.OBTenant{}
 	err := m.Client.Get(m.Ctx, types.NamespacedName{
 		Namespace: m.BackupPolicy.Namespace,
-		Name:      tenantName,
+		Name:      tenantCRName,
 	}, tenant)
 	if err != nil {
 		if !kubeerrors.IsNotFound(err) {
-			m.Logger.Error(err, "get obtenant failed", "tenantName", tenantName, "namespaced", m.BackupPolicy.Namespace)
+			m.Logger.Error(err, "get obtenant failed", "tenantCRName", tenantCRName, "namespaced", m.BackupPolicy.Namespace)
 		}
 		return nil, err
 	}

--- a/pkg/resource/obtenantbackuppolicy_task.go
+++ b/pkg/resource/obtenantbackuppolicy_task.go
@@ -193,8 +193,16 @@ func (m *ObTenantBackupPolicyManager) StopBackup() error {
 	if err != nil {
 		return err
 	}
-
-	_ = con.DisableArchiveLogForTenant()
+	tenantInfo, err := m.getTenantRecord(false)
+	if err != nil {
+		return err
+	}
+	if tenantInfo.LogMode != "NOARCHIVELOG" {
+		err = con.DisableArchiveLogForTenant()
+		if err != nil {
+			return err
+		}
+	}
 
 	err = con.StopBackupJobOfTenant()
 	if err != nil {

--- a/pkg/resource/obtenantbackuppolicy_task.go
+++ b/pkg/resource/obtenantbackuppolicy_task.go
@@ -471,7 +471,7 @@ func (m *ObTenantBackupPolicyManager) getOperationManager() (*operation.Oceanbas
 		tenantCR := &v1alpha1.OBTenant{}
 		err = m.Client.Get(m.Ctx, types.NamespacedName{
 			Namespace: m.BackupPolicy.Namespace,
-			Name:      m.BackupPolicy.Spec.TenantName,
+			Name:      m.BackupPolicy.Spec.TenantCRName,
 		}, tenantCR)
 		if err != nil {
 			return nil, err

--- a/pkg/resource/obtenantrestore_manager.go
+++ b/pkg/resource/obtenantrestore_manager.go
@@ -134,8 +134,8 @@ func (m *ObTenantRestoreManager) checkRestoreProgress() error {
 		if restoreHistory != nil && restoreHistory.Status == "SUCCESS" {
 			m.Recorder.Event(m.Resource, corev1.EventTypeNormal, "Restore job finished", "Restore job finished")
 			if m.Resource.Spec.RestoreRole == constants.TenantRoleStandby {
-				if m.Resource.Spec.Source.ReplayEnabled && !m.Resource.Spec.Source.Until.Unlimited {
-					// Only if replay is enabled and restore until is not unlimited, start log replay
+				if m.Resource.Spec.Source.ReplayEnabled {
+					// Only if replay is enabled start log replay
 					m.Resource.Status.Status = constants.RestoreJobStatusReplaying
 				} else {
 					m.Resource.Status.Status = constants.RestoreJobSuccessful


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

1. In v4.2.1, `SELECT ... UNION ALL SELECT ...` syntax is not supported, which is used in selecting DataDeleteJob and DataDeleteJobHistory
2. BackupPolicy find OBTenant CR with name of tenant in Database, which leads to NotFound error
