### PR TITLE
fix #141: change failure rule of recover observer to retry from current

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -38,4 +38,4 @@ spec:
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
         - "--manager-namespace=oceanbase-system"
-        - "--log-verbosity=2"
+        - "--log-verbosity=0"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -73,10 +73,6 @@ spec:
         image: controller:latest
         name: manager
         env:
-          - name: TELEMETRY_DEBUG
-            value: "true"
-          - name: DISABLE_TELEMETRY
-            value: "true"
           - name: TELEMETRY_REPORT_HOST
             value: "https://openwebapi.oceanbase.com"
         securityContext:

--- a/internal/resource/observer/observer_flow.go
+++ b/internal/resource/observer/observer_flow.go
@@ -14,6 +14,7 @@ package observer
 
 import (
 	serverstatus "github.com/oceanbase/ob-operator/internal/const/status/observer"
+	"github.com/oceanbase/ob-operator/pkg/task/const/strategy"
 	tasktypes "github.com/oceanbase/ob-operator/pkg/task/types"
 )
 
@@ -73,6 +74,9 @@ func RecoverOBServer() *tasktypes.TaskFlow {
 			Name:         fRecoverOBServer,
 			Tasks:        []tasktypes.TaskName{tCreateOBPod, tWaitOBServerReady, tWaitOBServerActiveInCluster},
 			TargetStatus: serverstatus.Running,
+			OnFailure: tasktypes.FailureRule{
+				Strategy: strategy.RetryFromCurrent,
+			},
 		},
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
change strategy of failure rule to retry from current when recover observer
delete some debug related configurations under config


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
After checking the code, first task of recover observer flow is to create the pod, the only operation that takes effect is to call the client to create the pod, simply change the retry strategy to from current task will prevent ob-operator trying to recreate the pod when it's already created
Tested with the following step:
1. create an obcluster
2. delete a pod
3. delete ob-operator's pod when observer is still recovering, so the task will fail
4. wait ob-operator restarts
5. check observer recovers