### PR TITLE
Remove httpOnly cookie on server

### DIFF
--- a/distribution/dashboard/internal/handler/user_handler.go
+++ b/distribution/dashboard/internal/handler/user_handler.go
@@ -89,6 +89,7 @@ func Logout(c *gin.Context) {
 	sess := sessions.Default(c)
 	usernameEntry := sess.Get("username")
 	sess.Clear()
+	sess.Options(sessions.Options{Path: "/", MaxAge: -1}) // this sets the cookie with a MaxAge of 0
 	if err := sess.Save(); err != nil {
 		logHandlerError(c, err)
 		SendInternalServerErrorResponse(c, nil, err)

--- a/distribution/dashboard/internal/middleware/authentication.go
+++ b/distribution/dashboard/internal/middleware/authentication.go
@@ -46,10 +46,8 @@ func LoginRequired() gin.HandlerFunc {
 		}
 		expriration := time.Unix(expr.(int64), 0)
 		if expriration.Before(time.Now()) {
-			c.AbortWithStatusJSON(401, gin.H{
-				"message": "login expired, please login again",
-			})
 			session.Clear()
+			session.Options(sessions.Options{Path: "/", MaxAge: -1}) // this sets the cookie with a MaxAge of 0
 			err := session.Save()
 			if err != nil {
 				log.Errorf("failed to save session: %v", err)
@@ -58,6 +56,9 @@ func LoginRequired() gin.HandlerFunc {
 				})
 			}
 			store.GetCache().Delete(username)
+			c.AbortWithStatusJSON(401, gin.H{
+				"message": "login expired, please login again",
+			})
 			return
 		}
 		c.Next()

--- a/distribution/dashboard/internal/router/router.go
+++ b/distribution/dashboard/internal/router/router.go
@@ -9,11 +9,13 @@ import (
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-contrib/static"
 	"github.com/gin-gonic/gin"
+	swaggerfiles "github.com/swaggo/files"
+	ginSwagger "github.com/swaggo/gin-swagger"
+
 	"github.com/oceanbase/oceanbase-dashboard/docs"
 	"github.com/oceanbase/oceanbase-dashboard/internal/middleware"
 	v1 "github.com/oceanbase/oceanbase-dashboard/internal/router/v1"
-	swaggerfiles "github.com/swaggo/files"
-	ginSwagger "github.com/swaggo/gin-swagger"
+	"github.com/oceanbase/oceanbase-dashboard/internal/server/constant"
 )
 
 func InitRoutes(router *gin.Engine) {
@@ -24,6 +26,8 @@ func InitRoutes(router *gin.Engine) {
 	store := cookie.NewStore([]byte(sessionSecret))
 	store.Options(sessions.Options{
 		HttpOnly: true,
+		MaxAge:   constant.DefaultSessionExpiration,
+		Path:     "/",
 	})
 	// use gin's crash free middleware
 	router.Use(


### PR DESCRIPTION
To delete an HttpOnly cookie, you must do so from the server side, since HttpOnly cookies are not accessible via JavaScript for security reasons. To delete such a cookie, the server must send an HTTP response with a Set-Cookie header that contains the same cookie name but with an expiration date in the past. This tells the client's browser to remove the cookie immediately.