### PR TITLE
Fix mismatched bool parameter due to mismatched cases

### DIFF
--- a/internal/resource/obparameter/obparameter_manager.go
+++ b/internal/resource/obparameter/obparameter_manager.go
@@ -15,6 +15,7 @@ package obparameter
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -158,7 +159,7 @@ func (m *OBParameterManager) UpdateStatus() error {
 				Server: fmt.Sprintf("%s:%d", parameterInfo.SvrIp, parameterInfo.SvrPort),
 			}
 			parameterValues = append(parameterValues, parameterValue)
-			if parameterInfo.Value != m.OBParameter.Spec.Parameter.Value {
+			if strings.ToLower(parameterInfo.Value) != strings.ToLower(m.OBParameter.Spec.Parameter.Value) {
 				parameterMatched = false
 			}
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

In OceanBase database, bool parameters have value `True` or `False`. If we send `true` or `false`, they will never match.

## Solution Description
<!-- Please clearly and concisely describe your solution. -->

Compare desired value and actual value in lower case.
