### PR TITLE
Use service IP as IP of observer to ensure more robust recovery

### DIFF
--- a/api/types/observer_replica_status.go
+++ b/api/types/observer_replica_status.go
@@ -13,7 +13,14 @@ See the Mulan PSL v2 for more details.
 package types
 
 type OBServerReplicaStatus struct {
-	Server    string `json:"server"`
+	Server    string `json:"server"` // PodIP
 	Status    string `json:"status"`
 	ServiceIP string `json:"serviceIP,omitempty"`
+}
+
+func (srs OBServerReplicaStatus) GetConnectAddr() string {
+	if srs.ServiceIP != "" {
+		return srs.ServiceIP
+	}
+	return srs.Server
 }

--- a/api/types/observer_replica_status.go
+++ b/api/types/observer_replica_status.go
@@ -13,6 +13,7 @@ See the Mulan PSL v2 for more details.
 package types
 
 type OBServerReplicaStatus struct {
-	Server string `json:"server"`
-	Status string `json:"status"`
+	Server    string `json:"server"`
+	Status    string `json:"status"`
+	ServiceIP string `json:"serviceIP,omitempty"`
 }

--- a/api/v1alpha1/observer_types.go
+++ b/api/v1alpha1/observer_types.go
@@ -55,6 +55,7 @@ type OBServerStatus struct {
 	PodPhase         corev1.PodPhase             `json:"podPhase"`
 	Ready            bool                        `json:"ready"`
 	PodIp            string                      `json:"podIp"`
+	ServiceIp        string                      `json:"serviceIp,omitempty"`
 	NodeIp           string                      `json:"nodeIp"`
 	OBStatus         string                      `json:"obStatus,omitempty"`
 	StartServiceTime int64                       `json:"startServiceTime,omitempty"`

--- a/api/v1alpha1/observer_types.go
+++ b/api/v1alpha1/observer_types.go
@@ -17,11 +17,11 @@ limitations under the License.
 package v1alpha1
 
 import (
-	apitypes "github.com/oceanbase/ob-operator/api/types"
-	tasktypes "github.com/oceanbase/ob-operator/pkg/task/types"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apitypes "github.com/oceanbase/ob-operator/api/types"
+	tasktypes "github.com/oceanbase/ob-operator/pkg/task/types"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -91,4 +91,11 @@ type OBServerList struct {
 
 func init() {
 	SchemeBuilder.Register(&OBServer{}, &OBServerList{})
+}
+
+func (ss OBServerStatus) GetConnectAddr() string {
+	if ss.ServiceIp != "" {
+		return ss.ServiceIp
+	}
+	return ss.PodIp
 }

--- a/charts/ob-operator/templates/operator.yaml
+++ b/charts/ob-operator/templates/operator.yaml
@@ -5731,6 +5731,8 @@ spec:
                 type: string
               ready:
                 type: boolean
+              serviceIp:
+                type: string
               startServiceTime:
                 format: int64
                 type: integer
@@ -11881,6 +11883,8 @@ spec:
                 items:
                   properties:
                     server:
+                      type: string
+                    serviceIP:
                       type: string
                     status:
                       type: string

--- a/config/crd/bases/oceanbase.oceanbase.com_observers.yaml
+++ b/config/crd/bases/oceanbase.oceanbase.com_observers.yaml
@@ -2693,6 +2693,8 @@ spec:
                 type: string
               ready:
                 type: boolean
+              serviceIp:
+                type: string
               startServiceTime:
                 format: int64
                 type: integer

--- a/config/crd/bases/oceanbase.oceanbase.com_obzones.yaml
+++ b/config/crd/bases/oceanbase.oceanbase.com_obzones.yaml
@@ -2685,6 +2685,8 @@ spec:
                   properties:
                     server:
                       type: string
+                    serviceIP:
+                      type: string
                     status:
                       type: string
                   required:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -5744,6 +5744,8 @@ spec:
                 type: string
               ready:
                 type: boolean
+              serviceIp:
+                type: string
               startServiceTime:
                 format: int64
                 type: integer
@@ -11894,6 +11896,8 @@ spec:
                 items:
                   properties:
                     server:
+                      type: string
+                    serviceIP:
                       type: string
                     status:
                       type: string

--- a/distribution/oceanbase/oceanbase-helper/cmd/start.go
+++ b/distribution/oceanbase/oceanbase-helper/cmd/start.go
@@ -143,10 +143,13 @@ func startOBServerWithParam() error {
 		return errors.Wrap(err, "Failed to parse current version")
 	}
 	var cmd string
+	svcIP := os.Getenv("SVC_IP")
 	if standalone != "" && obv.Cmp(MinStandaloneVersion) >= 0 {
 		cmd = fmt.Sprintf("cd %s && %s/bin/observer --nodaemon --appname %s --cluster_id %s --zone %s --devname lo -p %d -P %d -d %s/store -l info -o config_additional_dir=%s/store/etc,%s", DefaultHomePath, DefaultHomePath, clusterName, clusterId, zoneName, DefaultSqlPort, DefaultRpcPort, DefaultHomePath, DefaultHomePath, optStr)
+	} else if svcIP != "" {
+		cmd = fmt.Sprintf("cd %s && %s/bin/observer --nodaemon --appname %s --cluster_id %s --zone %s -I %s -p %d -P %d -d %s/store -l info -o config_additional_dir=%s/store/etc,%s", DefaultHomePath, DefaultHomePath, clusterName, clusterId, zoneName, svcIP, DefaultSqlPort, DefaultRpcPort, DefaultHomePath, DefaultHomePath, optStr)
 	} else {
-		cmd = fmt.Sprintf("cd %s && %s/bin/observer --nodaemon --appname %s --cluster_id %s --zone %s --devname %s -p %d -P %d -d %s/store -l info -o config_additional_dir=%s/store/etc,%s", DefaultHomePath, DefaultHomePath, clusterName, clusterId, zoneName, DefaultDevName, DefaultSqlPort, DefaultRpcPort, DefaultHomePath, DefaultHomePath, optStr)
+		cmd = fmt.Sprintf("cd %s && %s/bin/observer --nodaemon --appname %s --cluster_id %s --zone %s -i %s -p %d -P %d -d %s/store -l info -o config_additional_dir=%s/store/etc,%s", DefaultHomePath, DefaultHomePath, clusterName, clusterId, zoneName, DefaultDevName, DefaultSqlPort, DefaultRpcPort, DefaultHomePath, DefaultHomePath, optStr)
 	}
 	fmt.Println("Start commands: ", cmd)
 	return exec.Command("bash", "-c", cmd).Run()

--- a/internal/const/oceanbase/oceanbase.go
+++ b/internal/const/oceanbase/oceanbase.go
@@ -80,6 +80,7 @@ const (
 
 const (
 	ModeStandalone = "standalone"
+	ModeService    = "service"
 )
 
 const (

--- a/internal/resource/obcluster/obcluster_task.go
+++ b/internal/resource/obcluster/obcluster_task.go
@@ -31,12 +31,11 @@ import (
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	apitypes "github.com/oceanbase/ob-operator/api/types"
+	v1alpha1 "github.com/oceanbase/ob-operator/api/v1alpha1"
 	obagentconst "github.com/oceanbase/ob-operator/internal/const/obagent"
 	oceanbaseconst "github.com/oceanbase/ob-operator/internal/const/oceanbase"
 	zonestatus "github.com/oceanbase/ob-operator/internal/const/status/obzone"
-
-	apitypes "github.com/oceanbase/ob-operator/api/types"
-	v1alpha1 "github.com/oceanbase/ob-operator/api/v1alpha1"
 	resourceutils "github.com/oceanbase/ob-operator/internal/resource/utils"
 	"github.com/oceanbase/ob-operator/pkg/oceanbase-sdk/model"
 	"github.com/oceanbase/ob-operator/pkg/oceanbase-sdk/operation"
@@ -308,16 +307,11 @@ func (m *OBClusterManager) Bootstrap() tasktypes.TaskError {
 	} else {
 		connectAddress := manager.Connector.DataSource().GetAddress()
 		for _, zone := range obzoneList.Items {
-			serverIp := zone.Status.OBServerStatus[0].Server
-			if zone.Status.OBServerStatus[0].ServiceIP != "" {
-				serverIp = zone.Status.OBServerStatus[0].ServiceIP
-			}
+			serverIp := zone.Status.OBServerStatus[0].GetConnectAddr()
+			// Notes: If the addr of the db connector is in this obzone, use it as the bootstrap server instead of the first one
 			for _, serverInfo := range zone.Status.OBServerStatus {
-				if serverInfo.Server == connectAddress {
-					serverIp = serverInfo.Server
-					if serverInfo.ServiceIP != "" {
-						serverIp = serverInfo.ServiceIP
-					}
+				if serverInfo.Server == connectAddress || serverInfo.ServiceIP == connectAddress {
+					serverIp = serverInfo.GetConnectAddr()
 				}
 			}
 			serverInfo := &model.ServerInfo{

--- a/internal/resource/obcluster/obcluster_task.go
+++ b/internal/resource/obcluster/obcluster_task.go
@@ -308,10 +308,16 @@ func (m *OBClusterManager) Bootstrap() tasktypes.TaskError {
 	} else {
 		connectAddress := manager.Connector.DataSource().GetAddress()
 		for _, zone := range obzoneList.Items {
-			serverIp := zone.Status.OBServerStatus[0].ServiceIP
+			serverIp := zone.Status.OBServerStatus[0].Server
+			if zone.Status.OBServerStatus[0].ServiceIP != "" {
+				serverIp = zone.Status.OBServerStatus[0].ServiceIP
+			}
 			for _, serverInfo := range zone.Status.OBServerStatus {
 				if serverInfo.Server == connectAddress {
-					serverIp = serverInfo.ServiceIP
+					serverIp = serverInfo.Server
+					if serverInfo.ServiceIP != "" {
+						serverIp = serverInfo.ServiceIP
+					}
 				}
 			}
 			serverInfo := &model.ServerInfo{

--- a/internal/resource/obcluster/obcluster_task.go
+++ b/internal/resource/obcluster/obcluster_task.go
@@ -308,10 +308,10 @@ func (m *OBClusterManager) Bootstrap() tasktypes.TaskError {
 	} else {
 		connectAddress := manager.Connector.DataSource().GetAddress()
 		for _, zone := range obzoneList.Items {
-			serverIp := zone.Status.OBServerStatus[0].Server
+			serverIp := zone.Status.OBServerStatus[0].ServiceIP
 			for _, serverInfo := range zone.Status.OBServerStatus {
 				if serverInfo.Server == connectAddress {
-					serverIp = connectAddress
+					serverIp = serverInfo.ServiceIP
 				}
 			}
 			serverInfo := &model.ServerInfo{
@@ -1007,9 +1007,10 @@ func (m *OBClusterManager) CheckImageReady() tasktypes.TaskError {
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
-						Name:    "helper-check-image-pull-ready",
-						Image:   m.OBCluster.Spec.OBServerTemplate.Image,
-						Command: []string{"bash", "-c", "/home/admin/oceanbase/bin/oceanbase-helper help"},
+						Name:            "helper-check-image-pull-ready",
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Image:           m.OBCluster.Spec.OBServerTemplate.Image,
+						Command:         []string{"bash", "-c", "/home/admin/oceanbase/bin/oceanbase-helper help"},
 					}},
 					RestartPolicy: corev1.RestartPolicyNever,
 				},

--- a/internal/resource/observer/names.go
+++ b/internal/resource/observer/names.go
@@ -33,6 +33,7 @@ const (
 // observer tasks
 const (
 	tWaitOBClusterBootstrapped    ttypes.TaskName = "wait obcluster bootstrapped"
+	tCreateOBServerSvc            ttypes.TaskName = "create observer svc"
 	tCreateOBPVC                  ttypes.TaskName = "create observer pvc"
 	tCreateOBPod                  ttypes.TaskName = "create observer pod"
 	tAnnotateOBServerPod          ttypes.TaskName = "annotate observer pod"

--- a/internal/resource/observer/observer_flow.go
+++ b/internal/resource/observer/observer_flow.go
@@ -22,7 +22,7 @@ func PrepareOBServerForBootstrap() *tasktypes.TaskFlow {
 	return &tasktypes.TaskFlow{
 		OperationContext: &tasktypes.OperationContext{
 			Name:         fPrepareOBServerForBootstrap,
-			Tasks:        []tasktypes.TaskName{tCreateOBPVC, tCreateOBPod, tWaitOBServerReady},
+			Tasks:        []tasktypes.TaskName{tCreateOBServerSvc, tCreateOBPVC, tCreateOBPod, tWaitOBServerReady},
 			TargetStatus: serverstatus.BootstrapReady,
 		},
 	}

--- a/internal/resource/observer/observer_manager.go
+++ b/internal/resource/observer/observer_manager.go
@@ -200,7 +200,7 @@ func (m *OBServerManager) UpdateStatus() error {
 					err := m.Client.Get(m.Ctx, m.generateNamespacedName(m.OBServer.Name), svc)
 					if err != nil {
 						m.Logger.V(oceanbaseconst.LogLevelDebug).Info("get svc failed")
-					} else if svc != nil {
+					} else {
 						m.OBServer.Status.ServiceIp = svc.Spec.ClusterIP
 					}
 				}

--- a/internal/resource/observer/observer_manager.go
+++ b/internal/resource/observer/observer_manager.go
@@ -193,12 +193,17 @@ func (m *OBServerManager) UpdateStatus() error {
 			// TODO update from obcluster
 			m.OBServer.Status.CNI = resourceutils.GetCNIFromAnnotation(pod)
 
-			svc := &corev1.Service{}
-			err := m.Client.Get(m.Ctx, m.generateNamespacedName(m.OBServer.Name), svc)
-			if err != nil {
-				m.Logger.V(oceanbaseconst.LogLevelDebug).Info("get svc failed")
-			} else if svc != nil {
-				m.OBServer.Status.ServiceIp = svc.Spec.ClusterIP
+			if m.OBServer.Status.ServiceIp == "" {
+				mode, modeAnnoExist := resourceutils.GetAnnotationField(m.OBServer, oceanbaseconst.AnnotationsMode)
+				if modeAnnoExist && mode == oceanbaseconst.ModeService {
+					svc := &corev1.Service{}
+					err := m.Client.Get(m.Ctx, m.generateNamespacedName(m.OBServer.Name), svc)
+					if err != nil {
+						m.Logger.V(oceanbaseconst.LogLevelDebug).Info("get svc failed")
+					} else if svc != nil {
+						m.OBServer.Status.ServiceIp = svc.Spec.ClusterIP
+					}
+				}
 			}
 		}
 		pvcs, err := m.getPVCs()

--- a/internal/resource/observer/observer_manager.go
+++ b/internal/resource/observer/observer_manager.go
@@ -16,11 +16,8 @@ import (
 	"context"
 	"strings"
 
-	"github.com/oceanbase/ob-operator/internal/telemetry"
-	"github.com/oceanbase/ob-operator/pkg/oceanbase-sdk/model"
-	taskstatus "github.com/oceanbase/ob-operator/pkg/task/const/status"
-	"github.com/oceanbase/ob-operator/pkg/task/const/strategy"
-
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -29,17 +26,17 @@ import (
 	apipod "k8s.io/kubernetes/pkg/api/v1/pod"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	oceanbaseconst "github.com/oceanbase/ob-operator/internal/const/oceanbase"
-
-	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
-
 	v1alpha1 "github.com/oceanbase/ob-operator/api/v1alpha1"
+	oceanbaseconst "github.com/oceanbase/ob-operator/internal/const/oceanbase"
 	clusterstatus "github.com/oceanbase/ob-operator/internal/const/status/obcluster"
 	serverstatus "github.com/oceanbase/ob-operator/internal/const/status/observer"
 	resourceutils "github.com/oceanbase/ob-operator/internal/resource/utils"
+	"github.com/oceanbase/ob-operator/internal/telemetry"
 	opresource "github.com/oceanbase/ob-operator/pkg/coordinator"
+	"github.com/oceanbase/ob-operator/pkg/oceanbase-sdk/model"
 	"github.com/oceanbase/ob-operator/pkg/task"
+	taskstatus "github.com/oceanbase/ob-operator/pkg/task/const/status"
+	"github.com/oceanbase/ob-operator/pkg/task/const/strategy"
 	tasktypes "github.com/oceanbase/ob-operator/pkg/task/types"
 )
 
@@ -128,11 +125,8 @@ func (m *OBServerManager) getCurrentOBServerFromOB() (*model.OBServer, error) {
 		return nil, err
 	}
 	observerInfo := &model.ServerInfo{
-		Ip:   m.OBServer.Status.PodIp,
+		Ip:   m.OBServer.Status.GetConnectAddr(),
 		Port: oceanbaseconst.RpcPort,
-	}
-	if m.OBServer.Status.ServiceIp != "" {
-		observerInfo.Ip = m.OBServer.Status.ServiceIp
 	}
 	mode, modeExist := resourceutils.GetAnnotationField(m.OBServer, oceanbaseconst.AnnotationsMode)
 	if modeExist && mode == oceanbaseconst.ModeStandalone {

--- a/internal/resource/observer/observer_task.go
+++ b/internal/resource/observer/observer_task.go
@@ -867,35 +867,38 @@ outer:
 	return errors.Errorf("Timeout to wait for pvc resized")
 }
 func (m *OBServerManager) CreateOBServerSvc() tasktypes.TaskError {
-	m.Logger.Info("create observer service")
-	svc := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      m.OBServer.Name,
-			Namespace: m.OBServer.Namespace,
-			Labels:    m.OBServer.Labels,
-			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: m.OBServer.APIVersion,
-				Kind:       m.OBServer.Kind,
-				Name:       m.OBServer.Name,
-				UID:        m.OBServer.GetUID(),
-			}},
-		},
-		Spec: corev1.ServiceSpec{
-			Selector: m.OBServer.Labels,
-			Ports: []corev1.ServicePort{{
-				Name:       "sql",
-				Port:       oceanbaseconst.SqlPort,
-				TargetPort: intstr.IntOrString{IntVal: oceanbaseconst.SqlPort},
-			}, {
-				Name:       "rpc",
-				Port:       oceanbaseconst.RpcPort,
-				TargetPort: intstr.IntOrString{IntVal: oceanbaseconst.RpcPort},
-			}},
-		},
-	}
-	err := m.Client.Create(m.Ctx, svc)
-	if err != nil {
-		return errors.Wrapf(err, "Failed to create observer service")
+	mode, modeAnnoExist := resourceutils.GetAnnotationField(m.OBServer, oceanbaseconst.AnnotationsMode)
+	if modeAnnoExist && mode == oceanbaseconst.ModeService {
+		m.Logger.Info("create observer service")
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      m.OBServer.Name,
+				Namespace: m.OBServer.Namespace,
+				Labels:    m.OBServer.Labels,
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: m.OBServer.APIVersion,
+					Kind:       m.OBServer.Kind,
+					Name:       m.OBServer.Name,
+					UID:        m.OBServer.GetUID(),
+				}},
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: m.OBServer.Labels,
+				Ports: []corev1.ServicePort{{
+					Name:       "sql",
+					Port:       oceanbaseconst.SqlPort,
+					TargetPort: intstr.IntOrString{IntVal: oceanbaseconst.SqlPort},
+				}, {
+					Name:       "rpc",
+					Port:       oceanbaseconst.RpcPort,
+					TargetPort: intstr.IntOrString{IntVal: oceanbaseconst.RpcPort},
+				}},
+			},
+		}
+		err := m.Client.Create(m.Ctx, svc)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to create observer service")
+		}
 	}
 	return nil
 }

--- a/internal/resource/observer/observer_task.go
+++ b/internal/resource/observer/observer_task.go
@@ -74,11 +74,8 @@ func (m *OBServerManager) AddServer() tasktypes.TaskError {
 		return errors.Wrap(err, "Get oceanbase operation manager")
 	}
 	serverInfo := &model.ServerInfo{
-		Ip:   m.OBServer.Status.PodIp,
+		Ip:   m.OBServer.Status.GetConnectAddr(),
 		Port: oceanbaseconst.RpcPort,
-	}
-	if m.OBServer.Status.ServiceIp != "" {
-		serverInfo.Ip = m.OBServer.Status.ServiceIp
 	}
 	obs, err := oceanbaseOperationManager.GetServer(serverInfo)
 	if obs != nil {
@@ -595,11 +592,8 @@ func (m *OBServerManager) DeleteOBServerInCluster() tasktypes.TaskError {
 		return errors.Wrapf(err, "Get oceanbase operation manager failed")
 	}
 	observerInfo := &model.ServerInfo{
-		Ip:   m.OBServer.Status.PodIp,
+		Ip:   m.OBServer.Status.GetConnectAddr(),
 		Port: oceanbaseconst.RpcPort,
-	}
-	if m.OBServer.Status.ServiceIp != "" {
-		observerInfo.Ip = m.OBServer.Status.ServiceIp
 	}
 	observer, err := operationManager.GetServer(observerInfo)
 	if err != nil {
@@ -689,11 +683,8 @@ func (m *OBServerManager) WaitOBServerActiveInCluster() tasktypes.TaskError {
 	}
 	m.Logger.Info("wait observer active in cluster")
 	observerInfo := &model.ServerInfo{
-		Ip:   m.OBServer.Status.PodIp,
+		Ip:   m.OBServer.Status.GetConnectAddr(),
 		Port: oceanbaseconst.RpcPort,
-	}
-	if m.OBServer.Status.ServiceIp != "" {
-		observerInfo.Ip = m.OBServer.Status.ServiceIp
 	}
 	active := false
 	for i := 0; i < oceanbaseconst.DefaultStateWaitTimeout; i++ {
@@ -723,11 +714,8 @@ func (m *OBServerManager) WaitOBServerActiveInCluster() tasktypes.TaskError {
 func (m *OBServerManager) WaitOBServerDeletedInCluster() tasktypes.TaskError {
 	m.Logger.Info("wait observer deleted in cluster")
 	observerInfo := &model.ServerInfo{
-		Ip:   m.OBServer.Status.PodIp,
+		Ip:   m.OBServer.Status.GetConnectAddr(),
 		Port: oceanbaseconst.RpcPort,
-	}
-	if m.OBServer.Status.ServiceIp != "" {
-		observerInfo.Ip = m.OBServer.Status.ServiceIp
 	}
 	mode, modeAnnoExist := resourceutils.GetAnnotationField(m.OBServer, oceanbaseconst.AnnotationsMode)
 	if modeAnnoExist && mode == oceanbaseconst.ModeStandalone {

--- a/internal/resource/obzone/obzone_manager.go
+++ b/internal/resource/obzone/obzone_manager.go
@@ -204,10 +204,12 @@ func (m *OBZoneManager) UpdateStatus() error {
 	// handle upgrade
 	allServerVersionSync := true
 	for _, observer := range observerList.Items {
-		observerReplicaStatusList = append(observerReplicaStatusList, apitypes.OBServerReplicaStatus{
-			Server: observer.Status.PodIp,
-			Status: observer.Status.Status,
-		})
+		observerReplica := apitypes.OBServerReplicaStatus{
+			Server:    observer.Status.PodIp,
+			Status:    observer.Status.Status,
+			ServiceIP: observer.Status.ServiceIp,
+		}
+		observerReplicaStatusList = append(observerReplicaStatusList, observerReplica)
 		if observer.Status.Status != serverstatus.Unrecoverable {
 			availableReplica++
 		}

--- a/internal/resource/utils/util.go
+++ b/internal/resource/utils/util.go
@@ -76,6 +76,9 @@ func GetTenantRootOperationClient(c client.Client, logger *logr.Logger, obcluste
 	var s *connector.OceanBaseDataSource
 	for _, observer := range observerList.Items {
 		address := observer.Status.PodIp
+		if observer.Status.ServiceIp != "" {
+			address = observer.Status.ServiceIp
+		}
 		switch obcluster.Status.Status {
 		case clusterstatus.New:
 			return nil, errors.New("Cluster is not bootstrapped")
@@ -116,6 +119,9 @@ func getSysClient(c client.Client, logger *logr.Logger, obcluster *v1alpha1.OBCl
 	var s *connector.OceanBaseDataSource
 	for _, observer := range observerList.Items {
 		address := observer.Status.PodIp
+		if observer.Status.ServiceIp != "" {
+			address = observer.Status.ServiceIp
+		}
 		switch obcluster.Status.Status {
 		case clusterstatus.New:
 			s = connector.NewOceanBaseDataSource(address, oceanbaseconst.SqlPort, oceanbaseconst.RootUser, tenantName, "", "")

--- a/internal/resource/utils/util.go
+++ b/internal/resource/utils/util.go
@@ -75,10 +75,7 @@ func GetTenantRootOperationClient(c client.Client, logger *logr.Logger, obcluste
 
 	var s *connector.OceanBaseDataSource
 	for _, observer := range observerList.Items {
-		address := observer.Status.PodIp
-		if observer.Status.ServiceIp != "" {
-			address = observer.Status.ServiceIp
-		}
+		address := observer.Status.GetConnectAddr()
 		switch obcluster.Status.Status {
 		case clusterstatus.New:
 			return nil, errors.New("Cluster is not bootstrapped")
@@ -118,10 +115,7 @@ func getSysClient(c client.Client, logger *logr.Logger, obcluster *v1alpha1.OBCl
 
 	var s *connector.OceanBaseDataSource
 	for _, observer := range observerList.Items {
-		address := observer.Status.PodIp
-		if observer.Status.ServiceIp != "" {
-			address = observer.Status.ServiceIp
-		}
+		address := observer.Status.GetConnectAddr()
 		switch obcluster.Status.Status {
 		case clusterstatus.New:
 			s = connector.NewOceanBaseDataSource(address, oceanbaseconst.SqlPort, oceanbaseconst.RootUser, tenantName, "", "")


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

Create service for every single observer, take clusterIP of the service as IP of observer in the database. I have tested the functionalities like bootstrapping, adding server, recovering in place.

fix #93, #122