### PR TITLE
Feat:add tenant list page

### DIFF
--- a/distribution/dashboard/ui/mock/obclusterAPI.ts
+++ b/distribution/dashboard/ui/mock/obclusterAPI.ts
@@ -80,7 +80,7 @@ export default {
       namespace: 'oceanbase',
       createTime: 'string',
       name: 'test',
-      status: 'operating',
+      status: 'running',
       image: 'oceanbasedev/oceanbase-cn:4.1.0.1-test',
       metrics: {
         cpuPercent: 10,
@@ -93,7 +93,7 @@ export default {
           namespace: 'topology',
           zone: 'zone1',
           replicas: '2',
-          status: 'deleting',
+          status: 'running',
           rootService: '1.1.1.1',
           nodeSelector: [
             {
@@ -120,7 +120,7 @@ export default {
           namespace: 'topology2',
           zone: 'zone2',
           replicas: '1',
-          status: 'deleting',
+          status: 'running',
           rootService: '1.1.1.1',
           nodeSelector: [
             {
@@ -132,7 +132,7 @@ export default {
             {
               name: 'obcluster-obzone2-xxxxxx',
               namespace: 'observers2',
-              status: 'deleting',
+              status: 'running',
               address: '1.1.12.2',
               metrics: {
                 cpuPercent: '40',

--- a/distribution/dashboard/ui/src/components/MonitorComp/LineGraph.tsx
+++ b/distribution/dashboard/ui/src/components/MonitorComp/LineGraph.tsx
@@ -20,18 +20,12 @@ export type MetricType = {
 export interface LineGraphProps {
   id: string;
   metrics: MetricType[];
-  labels: { key: string; value: string }[];
+  labels: API.MetricsLabels;
   queryRange: QueryRangeType;
   height?: number;
   isRefresh?: boolean;
   type?: 'detail' | 'overview';
 }
-
-type queryRangeType = {
-  endTimestamp: number;
-  startTimestamp: number;
-  step: number; //每个点位间隔时间s 例如 半小时1800s 间隔step 30s 返回60个点位
-};
 
 export default function LineGraph({
   id,

--- a/distribution/dashboard/ui/src/components/MonitorComp/index.tsx
+++ b/distribution/dashboard/ui/src/components/MonitorComp/index.tsx
@@ -18,7 +18,7 @@ import styles from './index.less';
 // obzone
 
 interface MonitorCompProps {
-  filterLabel: { key: string; value: string }[];
+  filterLabel: API.MetricsLabels;
   queryRange: QueryRangeType;
   isRefresh?: boolean;
   queryScope:API.EventObjectType;

--- a/distribution/dashboard/ui/src/components/TopoComponent/G6register.tsx
+++ b/distribution/dashboard/ui/src/components/TopoComponent/G6register.tsx
@@ -37,9 +37,9 @@ function config(width: number, height: number) {
     width,
     height,
     linkCenter: true,
-    // fitCenter: true,
+    fitViewPadding: [-350,24,24,24],
     fitView: true,
-    maxZoom: 2,
+    maxZoom: 1.6,
     minZoom: 0.2,
     layout: {
       type: 'compactBox',

--- a/distribution/dashboard/ui/src/components/TopoComponent/constants.ts
+++ b/distribution/dashboard/ui/src/components/TopoComponent/constants.ts
@@ -1,7 +1,7 @@
 import { intl } from '@/utils/intl';
-type OperateType = { value: string; label: string }[];
+type OperateTypeLabel = { value: string; label: string }[];
 
-const clusterOperate: OperateType = [
+const clusterOperate: OperateTypeLabel = [
   {
     value: 'addZone',
     label: intl.formatMessage({
@@ -25,7 +25,7 @@ const clusterOperate: OperateType = [
   },
 ];
 
-const zoneOperate: OperateType = [
+const zoneOperate: OperateTypeLabel = [
   {
     value: 'scaleServer',
     label: intl.formatMessage({
@@ -42,7 +42,7 @@ const zoneOperate: OperateType = [
   },
 ];
 
-const serverOperate: OperateType = [
+const serverOperate: OperateTypeLabel = [
   // {
   //   value: 'add',
   //   label: intl.formatMessage({
@@ -66,5 +66,25 @@ const serverOperate: OperateType = [
   // },
 ];
 
-export { clusterOperate, serverOperate, zoneOperate };
-export type { OperateType };
+const clusterOperateOfTenant: OperateTypeLabel = [
+  {
+    value: 'changeUnitCount',
+    label: '修改 Unit 数量',
+  },
+];
+
+const zoneOperateOfTenant: OperateTypeLabel = [
+  {
+    value: 'modifyUnitSpecification',
+    label: '调整 Unit 规格',
+  },
+];
+
+export {
+  clusterOperate,
+  clusterOperateOfTenant,
+  serverOperate,
+  zoneOperate,
+  zoneOperateOfTenant,
+};
+export type { OperateTypeLabel };

--- a/distribution/dashboard/ui/src/components/customModal/ModifyUnitDetailModal.tsx
+++ b/distribution/dashboard/ui/src/components/customModal/ModifyUnitDetailModal.tsx
@@ -2,7 +2,7 @@ import { SUFFIX_UNIT } from '@/constants';
 import { getNSName } from '@/pages/Cluster/Detail/Overview/helper';
 import { patchTenantConfiguration } from '@/services/tenant';
 
-import { Form, InputNumber, message } from 'antd';
+import { Col, Form, InputNumber, Row, message } from 'antd';
 import type { CommonModalType } from '.';
 import CustomModal from '.';
 export default function ModifyUnitDetailModal({
@@ -51,7 +51,7 @@ export default function ModifyUnitDetailModal({
             },
           ]}
         >
-          <InputNumber addonAfter='核' placeholder="请输入" />
+          <InputNumber addonAfter="核" placeholder="请输入" />
         </Form.Item>
         <Form.Item
           label="Memory"
@@ -68,12 +68,18 @@ export default function ModifyUnitDetailModal({
         <Form.Item label="LogDiskSize" name="logDiskSize">
           <InputNumber addonAfter={SUFFIX_UNIT} placeholder="请输入" />
         </Form.Item>
-        <Form.Item label="min iops" name="minIops">
-          <InputNumber placeholder="请输入" />
-        </Form.Item>
-        <Form.Item label="max iops" name="maxIops">
-          <InputNumber placeholder="请输入" />
-        </Form.Item>
+        <Row gutter={24}>
+          <Col>
+            <Form.Item label="min iops" name="minIops">
+              <InputNumber placeholder="请输入" />
+            </Form.Item>
+          </Col>
+          <Col>
+            <Form.Item label="max iops" name="maxIops">
+              <InputNumber placeholder="请输入" />
+            </Form.Item>
+          </Col>
+        </Row>
         <Form.Item label="iops权重" name="iopsWeight">
           <InputNumber placeholder="请输入" />
         </Form.Item>

--- a/distribution/dashboard/ui/src/components/customModal/ModifyUnitModal.tsx
+++ b/distribution/dashboard/ui/src/components/customModal/ModifyUnitModal.tsx
@@ -1,6 +1,6 @@
 import { getNSName } from '@/pages/Cluster/Detail/Overview/helper';
 import { patchTenantConfiguration } from '@/services/tenant';
-import { Form, Input, message } from 'antd';
+import { Form, InputNumber, message } from 'antd';
 import type { CommonModalType } from '.';
 import CustomModal from '.';
 
@@ -56,7 +56,7 @@ export default function ModifyUnitModal({
             },
           ]}
         >
-          <Input placeholder="请输入" />
+          <InputNumber placeholder="请输入" />
         </Form.Item>
       </Form>
     </CustomModal>

--- a/distribution/dashboard/ui/src/components/customModal/OperateModal.tsx
+++ b/distribution/dashboard/ui/src/components/customModal/OperateModal.tsx
@@ -8,6 +8,7 @@ import ScaleModal from './ScaleModal';
 import SwitchTenantModal from './SwitchTenantModal';
 import UpgradeModal from './UpgradeModal';
 import UpgradeTenantModal from './UpgradeTenantModal';
+import ModifyUnitDetailModal from './ModifyUnitDetailModal';
 
 interface OperateModalProps {
   type: API.ModalType;
@@ -28,12 +29,8 @@ export default function OperateModal({
     return <ScaleModal {...props} />;
   }
 
-  if (type === 'upgrade') {
+  if (type === 'upgradeCluster') {
     return <UpgradeModal {...props} />;
-  }
-
-  if (type === 'modifyUnit') {
-    return <ModifyUnitModal {...props} />;
   }
 
   if (type === 'changePassword') {
@@ -52,6 +49,14 @@ export default function OperateModal({
 
   if (type === 'upgradeTenant') {
     return <UpgradeTenantModal {...props} />;
+  }
+
+  if(type === 'modifyUnitSpecification'){
+    return <ModifyUnitDetailModal {...props} />
+  }
+
+  if(type === 'changeUnitCount'){
+    return <ModifyUnitModal {...props} />;
   }
 
   return;

--- a/distribution/dashboard/ui/src/components/moreModal/index.tsx
+++ b/distribution/dashboard/ui/src/components/moreModal/index.tsx
@@ -2,11 +2,9 @@ import styles from './index.less';
 
 interface MoreModalProps {
   visible: boolean;
-  //   setVisible: (prop: boolean) => void;
-  ItemClick: (value: string, id: string) => void;
+  ItemClick: (value: API.ModalType) => void;
   list: { value: string; label: string }[];
   innerRef: any;
-  id: string;
   disable: boolean;
 }
 
@@ -15,7 +13,6 @@ export default function MoreModal({
   list,
   ItemClick,
   innerRef,
-  id,
   disable,
 }: MoreModalProps) {
   return (
@@ -24,7 +21,15 @@ export default function MoreModal({
       className={visible ? `${styles.moreContainer}` : `${styles.hidden}`}
     >
       {list.map((item, index) => (
-        <li style={disable ? {color:'rgba(0, 0, 0, 0.45)',cursor:'not-allowed'} : {}} onClick={!disable ? () => ItemClick(item.value, id) : ()=>{}} key={index}>
+        <li
+          style={
+            disable
+              ? { color: 'rgba(0, 0, 0, 0.45)', cursor: 'not-allowed' }
+              : {}
+          }
+          onClick={!disable ? () => ItemClick(item.value as API.ModalType) : () => {}}
+          key={index}
+        >
           {item.label}
         </li>
       ))}

--- a/distribution/dashboard/ui/src/pages/Cluster/Detail/Tenant/index.tsx
+++ b/distribution/dashboard/ui/src/pages/Cluster/Detail/Tenant/index.tsx
@@ -1,4 +1,60 @@
-// 某个集群下的租户列表
+import EventsTable from '@/components/EventsTable';
+import MonitorComp from '@/components/MonitorComp';
+import TenantsList from '@/pages/Tenant/TenantsList';
+import { getClusterDetailReq } from '@/services';
+import { getAllTenants } from '@/services/tenant';
+import { PageContainer } from '@ant-design/pro-components';
+import { useNavigate } from '@umijs/max';
+import { useRequest } from 'ahooks';
+import { Row } from 'antd';
+import BasicInfo from '../Overview/BasicInfo';
+import { getNSName } from '../Overview/helper';
+
+const defaultQueryRange = {
+  step: 20,
+  endTimestamp: Math.floor(new Date().valueOf() / 1000),
+  startTimestamp: Math.floor(new Date().valueOf() / 1000) - 60 * 30,
+};
+
 export default function Tenant() {
-  return <h1>Tenant</h1>;
+  const [ns, name, clusterName] = getNSName();
+  const navigate = useNavigate();
+  const { data: tenantsListResponse, run: getTenantsList } = useRequest(
+    getAllTenants,
+    {
+      manual: true,
+    },
+  );
+  const { data: clusterDetail } = useRequest(getClusterDetailReq, {
+    defaultParams: [{ name, ns }],
+    onSuccess: (res) => {
+      if (res?.info?.name) {
+        getTenantsList(res.name);
+      }
+    },
+  });
+  const tenantsList = tenantsListResponse?.data;
+  const handleAddCluster = () => navigate('/tenant/new');
+  return (
+    <PageContainer>
+      <Row gutter={[16, 16]}>
+        {clusterDetail && (
+          <BasicInfo {...(clusterDetail.info as API.ClusterInfo)} />
+        )}
+        {tenantsList && (
+          <TenantsList
+            tenantsList={tenantsList}
+            turnToCreateTenant={handleAddCluster}
+          />
+        )}
+        <EventsTable objectType="OBTENANT" />
+        <MonitorComp
+          queryRange={defaultQueryRange}
+          type="detail"
+          queryScope="OBTENANT"
+          filterLabel={[{ key: 'ob_cluster_name', value: clusterName }]}
+        />
+      </Row>
+    </PageContainer>
+  );
 }

--- a/distribution/dashboard/ui/src/pages/Cluster/index.tsx
+++ b/distribution/dashboard/ui/src/pages/Cluster/index.tsx
@@ -9,8 +9,7 @@ import MonitorComp from '@/components/MonitorComp';
 import ClusterList from './ClusterList';
 // import Monitor from './Monitor';
 import { getObclusterListReq } from '@/services';
-import type { LabelType } from './Detail/Monitor';
-import type { QueryRangeType } from './Detail/Monitor';
+import type { LabelType, QueryRangeType } from './Detail/Monitor';
 
 const defaultQueryRange:QueryRangeType = {
   step: 20,
@@ -44,7 +43,11 @@ const ClusterPage: React.FC = () => {
         />
         <EventsTable objectType="OBCLUSTER" />
       </Row>
-      <MonitorComp filterLabel={clusterNames} queryScope='OBCLUSTER_OVERVIEW' type='overview' queryRange={defaultQueryRange}/>
+      <MonitorComp 
+        filterLabel={clusterNames} 
+        queryScope='OBCLUSTER_OVERVIEW' 
+        type='overview' 
+        queryRange={defaultQueryRange}/>
     </PageContainer>
   );
 };

--- a/distribution/dashboard/ui/src/pages/Tenant/Detail/Overview/index.tsx
+++ b/distribution/dashboard/ui/src/pages/Tenant/Detail/Overview/index.tsx
@@ -32,7 +32,7 @@ export default function TenantOverview() {
   const [operateModalVisible, setOperateModalVisible] =
     useState<boolean>(false);
   //当前运维弹窗类型
-  const modalType = useRef<API.ModalType>('modifyUnit');
+  const modalType = useRef<API.ModalType>('changeUnitCount');
 
   const [[ns, name]] = useState(getNSName());
 
@@ -76,7 +76,7 @@ export default function TenantOverview() {
   const operateListConfig: OperateItemConfigType[] = [
     {
       text: 'Unit规格管理',
-      onClick: () => openOperateModal('modifyUnit'),
+      onClick: () => openOperateModal('changeUnitCount'),
       show: tenantDetail?.info.tenantRole === 'Primary',
       isMore: false,
     },

--- a/distribution/dashboard/ui/src/pages/Tenant/New/index.tsx
+++ b/distribution/dashboard/ui/src/pages/Tenant/New/index.tsx
@@ -10,7 +10,7 @@ import { formatNewTenantForm } from '../helper';
 import BasicInfo from './BasicInfo';
 import ResourcePools from './ResourcePools';
 import TenantSource from './TenantSource';
-// 新建租户页
+// New tenant page
 export default function New() {
   const navigate = useNavigate();
   const publicKey = usePublicKey();
@@ -20,13 +20,12 @@ export default function New() {
 
   const { data: clusterList = [] } = useRequest(getSimpleClusterList);
 
-  //选中的集群资源名
+  //Selected cluster resource name
   const clusterName = clusterList.filter(
     (cluster) => cluster.clusterId === selectClusterId,
   )[0]?.name;
-  //namespace最后提交的时候确认
+  
   const onFinish = async (values: any) => {
-    console.log('values', values);
     const ns = clusterList.filter(
       (cluster) => cluster.clusterId === selectClusterId,
     )[0]?.namespace;
@@ -49,7 +48,7 @@ export default function New() {
       header={{
         title: '创建租户',
         onBack: () => {
-          navigate('/tenant');
+          history.back()
         },
       }}
       footer={[

--- a/distribution/dashboard/ui/src/pages/Tenant/TenantsList.tsx
+++ b/distribution/dashboard/ui/src/pages/Tenant/TenantsList.tsx
@@ -6,7 +6,7 @@ import type { ColumnsType } from 'antd/es/table';
 import styles from './index.less';
 
 interface TenantsListProps {
-  tenantsList: API.TenantsListResponse | undefined;
+  tenantsList: API.TenantDetail[] | undefined;
   turnToCreateTenant: () => void;
 }
 

--- a/distribution/dashboard/ui/src/pages/Tenant/index.tsx
+++ b/distribution/dashboard/ui/src/pages/Tenant/index.tsx
@@ -5,10 +5,12 @@ import { Row } from 'antd';
 import { useState } from 'react';
 
 import EventsTable from '@/components/EventsTable';
+import MonitorComp from '@/components/MonitorComp';
 import { getAllTenants } from '@/services/tenant';
 import TenantsList from './TenantsList';
 
-import type { QueryRangeType } from '../Cluster/Detail/Monitor';
+
+import type { LabelType, QueryRangeType } from '../Cluster/Detail/Monitor';
 
 const defaultQueryRange: QueryRangeType = {
   step: 20,
@@ -17,9 +19,18 @@ const defaultQueryRange: QueryRangeType = {
 };
 // 租户概览页
 export default function TenantPage() {
-  const [filterLabel, setFilterLabel] = useState([]);
+  const [filterLabel, setFilterLabel] = useState<LabelType[]>([]);
   const navigate = useNavigate();
-  const { data: tenantsListResponse } = useRequest(getAllTenants, {});
+  const { data: tenantsListResponse } = useRequest(getAllTenants, {
+    onSuccess:({data,successful})=>{
+      if(successful){
+        setFilterLabel(data.map((item)=>({
+          key:'tenant_name',
+          value:item.tenantName
+        })));
+      }
+    }
+  });
   const handleAddCluster = () => navigate('new');
   const tenantsList = tenantsListResponse?.data
   return (
@@ -34,12 +45,12 @@ export default function TenantPage() {
 
         <EventsTable objectType="OBTENANT" />
       </Row>
-      {/* <MonitorComp
+      <MonitorComp
         filterLabel={filterLabel}
-        queryScope="OBCLUSTER_OVERVIEW"
+        queryScope="OBTENANT"
         type="overview"
         queryRange={defaultQueryRange}
-      /> */}
+      />
     </PageContainer>
   );
 }

--- a/distribution/dashboard/ui/src/services/typings.d.ts
+++ b/distribution/dashboard/ui/src/services/typings.d.ts
@@ -89,19 +89,31 @@ declare namespace API {
   type ClusterList = ClusterItem[];
 
   type ModalType =
-    | 'upgrade'
+    | 'upgradeCluster'
     | 'addZone'
     | 'scaleServer'
-    | 'modifyUnit'
     | 'changePassword'
     | 'logReplay'
     | 'activateTenant'
     | 'switchTenant'
-    | 'upgradeTenant';
+    | 'upgradeTenant'
+    | 'changeUnitCount'
+    | 'modifyUnitSpecification'
+    | 'deleteCluster'
+    | 'deleteZone'
 
+  type LableKeys =
+    | 'ob_cluster_name'
+    | 'ob_cluster_id'
+    | 'tenant_name'
+    | 'tenant_id'
+    | 'svr_ip'
+    | 'obzone';
+
+  type MetricsLabels = { key: LableKeys; value: string }[];
   type QueryMetricsType = {
     groupLabels: string[];
-    labels: { key: string; value: string }[];
+    labels: MetricsLabels;
     metrics: string[];
     queryRange: { endTimestamp: number; startTimestamp: number; step: number };
   };
@@ -161,7 +173,8 @@ declare namespace API {
     status: string;
     statusInDatabase: string;
     type: string;
-  }[]
+  }
+  [];
 
   type NamespaceAndName = {
     ns: string;
@@ -249,7 +262,7 @@ declare namespace API {
   }
 
   interface BackupJobsResponse extends CommonResponse {
-    data:BackupJob[];
+    data: BackupJob[];
   }
 
   interface TenantInfoType extends CommonResponse {


### PR DESCRIPTION
## Summary
1. Add a modal for modifying units to the topology map.
![image](https://github.com/oceanbase/ob-operator/assets/62841398/6c59a39f-c018-4a30-b495-a39db7b5e01f)
![image](https://github.com/oceanbase/ob-operator/assets/62841398/6b29f060-8d55-4e1b-984d-55a12c7ece19)

2. Add tenant list page in cluster details.

![image](https://github.com/oceanbase/ob-operator/assets/62841398/0990193c-74c7-482f-8dd0-cf6a65b64523)


