### PR TITLE
fix:Monitoring on the cluster overview page should be displayed in cluster dimensions

### DIFF
--- a/distribution/dashboard/ui/src/components/MonitorComp/LineGraph.tsx
+++ b/distribution/dashboard/ui/src/components/MonitorComp/LineGraph.tsx
@@ -24,7 +24,7 @@ export interface LineGraphProps {
   queryRange: QueryRangeType;
   height?: number;
   isRefresh?: boolean;
-  type?: 'detail' | 'overview';
+  type?: API.MonitorUserFor;
 }
 
 export default function LineGraph({
@@ -34,7 +34,7 @@ export default function LineGraph({
   queryRange,
   height = 186,
   isRefresh = false,
-  type,
+  type = 'DETAIL',
 }: LineGraphProps) {
   const [, chooseClusterName] = getNSName();
   const [isEmpty, setIsEmpty] = useState<boolean>(true);
@@ -52,12 +52,13 @@ export default function LineGraph({
     if (chooseClusterName) {
       metricsKeys = metrics.map((metric: MetricType) => metric.key);
     }
-    if (type === 'overview') realLabels = [];
+    if (type === 'OVERVIEW') realLabels = [];
     return {
       groupLabels,
       labels: realLabels, //为空则查询全部集群
       metrics: metricsKeys,
       queryRange,
+      type
     };
   };
 
@@ -66,7 +67,8 @@ export default function LineGraph({
     for (let metric of metricsData) {
       values.push(metric.value);
     }
-
+    console.log('metricsData',metricsData);
+    
     const config = {
       data: metricsData,
       xField: 'date',

--- a/distribution/dashboard/ui/src/components/MonitorComp/index.tsx
+++ b/distribution/dashboard/ui/src/components/MonitorComp/index.tsx
@@ -22,7 +22,7 @@ interface MonitorCompProps {
   queryRange: QueryRangeType;
   isRefresh?: boolean;
   queryScope:API.EventObjectType;
-  type: 'detail' | 'overview';
+  type: API.MonitorUserFor;
 }
 
 export default function MonitorComp({

--- a/distribution/dashboard/ui/src/pages/Cluster/Detail/Monitor/index.tsx
+++ b/distribution/dashboard/ui/src/pages/Cluster/Detail/Monitor/index.tsx
@@ -146,7 +146,7 @@ export default function Monitor() {
         isRefresh={isRefresh}
         queryRange={queryRange}
         filterLabel={filterLabel}
-        type="detail"
+        type="DETAIL"
         queryScope="OBCLUSTER"
       />
     </div>

--- a/distribution/dashboard/ui/src/pages/Cluster/Detail/Tenant/index.tsx
+++ b/distribution/dashboard/ui/src/pages/Cluster/Detail/Tenant/index.tsx
@@ -50,7 +50,7 @@ export default function Tenant() {
         <EventsTable objectType="OBTENANT" />
         <MonitorComp
           queryRange={defaultQueryRange}
-          type="detail"
+          type="DETAIL"
           queryScope="OBTENANT"
           filterLabel={[{ key: 'ob_cluster_name', value: clusterName }]}
         />

--- a/distribution/dashboard/ui/src/pages/Cluster/index.tsx
+++ b/distribution/dashboard/ui/src/pages/Cluster/index.tsx
@@ -46,7 +46,7 @@ const ClusterPage: React.FC = () => {
       <MonitorComp 
         filterLabel={clusterNames} 
         queryScope='OBCLUSTER_OVERVIEW' 
-        type='overview' 
+        type='OVERVIEW' 
         queryRange={defaultQueryRange}/>
     </PageContainer>
   );

--- a/distribution/dashboard/ui/src/pages/Tenant/index.tsx
+++ b/distribution/dashboard/ui/src/pages/Tenant/index.tsx
@@ -48,7 +48,7 @@ export default function TenantPage() {
       <MonitorComp
         filterLabel={filterLabel}
         queryScope="OBTENANT"
-        type="overview"
+        type="OVERVIEW"
         queryRange={defaultQueryRange}
       />
     </PageContainer>

--- a/distribution/dashboard/ui/src/services/index.ts
+++ b/distribution/dashboard/ui/src/services/index.ts
@@ -1,5 +1,5 @@
-import { formatClusterData } from '@/pages/Cluster/Detail/Overview/helper';
 import { formatTopoData } from '@/components/TopoComponent/helper';
+import { formatClusterData } from '@/pages/Cluster/Detail/Overview/helper';
 import { intl } from '@/utils/intl'; //@ts-nocheck
 import { request } from '@umijs/max';
 import _ from 'lodash';
@@ -164,13 +164,13 @@ export async function getObclusterListReq() {
   return [];
 }
 
-export async function getSimpleClusterList():Promise<API.SimpleClusterList>  {
+export async function getSimpleClusterList(): Promise<API.SimpleClusterList> {
   const r = await request<API.ClusterListResponse>('/api/v1/obclusters', {
     method: 'GET',
   });
   if (r.successful) {
     return r.data.map((clusterDetail) => ({
-      clusterId:clusterDetail.clusterId,
+      clusterId: clusterDetail.clusterId,
       name: clusterDetail.name,
       namespace: clusterDetail.namespace,
       topology: clusterDetail.topology,
@@ -183,18 +183,18 @@ export async function getClusterDetailReq({
   ns,
   name,
   useFor,
-  tenantReplicas
+  tenantReplicas,
 }: {
   ns: string;
   name: string;
   useFor?: string;
-  tenantReplicas?:API.ReplicaDetailType[]
+  tenantReplicas?: API.ReplicaDetailType[];
 }) {
   const r = await request(`/api/v1/obclusters/namespace/${ns}/name/${name}`, {
     method: 'GET',
   });
   if (r.successful) {
-    if (useFor === 'topo') return formatTopoData(r.data,tenantReplicas);
+    if (useFor === 'topo') return formatTopoData(r.data, tenantReplicas);
     return formatClusterData(r.data);
   }
   return r.data;
@@ -389,7 +389,7 @@ export async function getAllMetrics(type: API.EventObjectType) {
 }
 
 // //时间戳换算成时间
-export async function queryMetricsReq(data: API.QueryMetricsType) {
+export async function queryMetricsReq({ type, ...data }: API.QueryMetricsType) {
   const r = await request('/api/v1/metrics/query', {
     method: 'POST',
     data,
@@ -400,7 +400,11 @@ export async function queryMetricsReq(data: API.QueryMetricsType) {
       metric.values.forEach((item) => {
         // item.date = moment.unix(item.timestamp).format('YYYY-MM-DD HH:mm:ss');
         item.date = item.timestamp * 1000;
-        item.name = metric.metric.name;
+        if (type === 'OVERVIEW') {
+          item.name = metric.metric.labels[0]?.value || '';
+        } else {
+          item.name = metric.metric.name;
+        }
       });
     });
     let res = _.flatten(r.data.map((metric) => metric.values));

--- a/distribution/dashboard/ui/src/services/typings.d.ts
+++ b/distribution/dashboard/ui/src/services/typings.d.ts
@@ -116,9 +116,12 @@ declare namespace API {
     labels: MetricsLabels;
     metrics: string[];
     queryRange: { endTimestamp: number; startTimestamp: number; step: number };
+    type:MonitorUserFor;
   };
 
   type EventType = 'NORMAL' | 'WARNING';
+
+  type MonitorUserFor = 'OVERVIEW' | 'DETAIL';
 
   type EventObjectType = 'OBCLUSTER' | 'OBTENANT' | 'OBCLUSTER_OVERVIEW';
 


### PR DESCRIPTION
## Summary
Modify the parameters of the monitoring query request to get names of clusters.

![image](https://github.com/oceanbase/ob-operator/assets/62841398/1519b87d-f887-42d5-81fe-6f5f77116ef8)



