### PR TITLE
Add resource labels; Coordinate when sub-resource changes

### DIFF
--- a/api/v1alpha1/obtenant_webhook.go
+++ b/api/v1alpha1/obtenant_webhook.go
@@ -66,12 +66,19 @@ func (r *OBTenant) Default() {
 	if err != nil {
 		tenantlog.Error(err, "Failed to get cluster")
 	} else {
+		clusterMeta := cluster.GetObjectMeta()
 		r.SetOwnerReferences([]metav1.OwnerReference{{
 			APIVersion: cluster.APIVersion,
 			Kind:       cluster.Kind,
-			Name:       cluster.GetObjectMeta().GetName(),
-			UID:        cluster.GetObjectMeta().GetUID(),
+			Name:       clusterMeta.GetName(),
+			UID:        clusterMeta.GetUID(),
 		}})
+		labels := r.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		labels[oceanbaseconst.LabelRefOBCluster] = clusterMeta.GetName()
+		r.SetLabels(labels)
 	}
 
 	if r.Spec.TenantRole == "" {

--- a/api/v1alpha1/obtenantbackuppolicy_webhook.go
+++ b/api/v1alpha1/obtenantbackuppolicy_webhook.go
@@ -111,7 +111,7 @@ func (r *OBTenantBackupPolicy) Default() {
 		}})
 
 		r.SetLabels(map[string]string{
-			oceanbaseconst.LabelTenantName:   r.Spec.TenantName,
+			oceanbaseconst.LabelTenantName:   r.Spec.TenantCRName,
 			oceanbaseconst.LabelRefOBCluster: r.Spec.ObClusterName,
 			oceanbaseconst.LabelRefUID:       string(tenant.GetObjectMeta().GetUID()),
 		})

--- a/api/v1alpha1/obtenantoperation_webhook.go
+++ b/api/v1alpha1/obtenantoperation_webhook.go
@@ -115,7 +115,7 @@ func (r *OBTenantOperation) Default() {
 			Name:       secondMeta.GetName(),
 			UID:        secondMeta.GetUID(),
 		})
-		labels[oceanbaseconst.LabelSecondTenant] = secondMeta.GetName()
+		labels[oceanbaseconst.LabelSecondaryTenant] = secondMeta.GetName()
 	}
 
 	r.SetOwnerReferences(references)

--- a/api/v1alpha1/obtenantoperation_webhook.go
+++ b/api/v1alpha1/obtenantoperation_webhook.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/oceanbase/ob-operator/api/constants"
 	apitypes "github.com/oceanbase/ob-operator/api/types"
+	oceanbaseconst "github.com/oceanbase/ob-operator/internal/const/oceanbase"
 )
 
 // log is for logging in this package.
@@ -73,6 +74,10 @@ func (r *OBTenantOperation) Default() {
 		targetTenantName = *r.Spec.TargetTenant
 	}
 	references := r.GetOwnerReferences()
+	labels := r.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
 
 	if targetTenantName != "" {
 		err := clt.Get(context.Background(), types.NamespacedName{
@@ -90,6 +95,7 @@ func (r *OBTenantOperation) Default() {
 			Name:       firstMeta.GetName(),
 			UID:        firstMeta.GetUID(),
 		})
+		labels[oceanbaseconst.LabelTenantName] = firstMeta.GetName()
 	}
 
 	if secondaryTenantName != "" {
@@ -109,9 +115,11 @@ func (r *OBTenantOperation) Default() {
 			Name:       secondMeta.GetName(),
 			UID:        secondMeta.GetUID(),
 		})
+		labels[oceanbaseconst.LabelSecondTenant] = secondMeta.GetName()
 	}
 
 	r.SetOwnerReferences(references)
+	r.SetLabels(labels)
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.

--- a/internal/const/oceanbase/oceanbase.go
+++ b/internal/const/oceanbase/oceanbase.go
@@ -144,9 +144,9 @@ const (
 )
 
 const (
-	LabelTenantName   = "oceanbase.oceanbase.com/tenant-name"
-	LabelSecondTenant = "oceanbase.oceanbase.com/second-tenant"
-	LabelBackupType   = "oceanbase.oceanbase.com/backup-type"
+	LabelTenantName      = "oceanbase.oceanbase.com/tenant-name"
+	LabelSecondaryTenant = "oceanbase.oceanbase.com/secondary-tenant"
+	LabelBackupType      = "oceanbase.oceanbase.com/backup-type"
 )
 
 const (

--- a/internal/const/oceanbase/oceanbase.go
+++ b/internal/const/oceanbase/oceanbase.go
@@ -144,8 +144,9 @@ const (
 )
 
 const (
-	LabelTenantName = "oceanbase.oceanbase.com/tenant-name"
-	LabelBackupType = "oceanbase.oceanbase.com/backup-type"
+	LabelTenantName   = "oceanbase.oceanbase.com/tenant-name"
+	LabelSecondTenant = "oceanbase.oceanbase.com/second-tenant"
+	LabelBackupType   = "oceanbase.oceanbase.com/backup-type"
 )
 
 const (

--- a/internal/controller/obcluster_controller.go
+++ b/internal/controller/obcluster_controller.go
@@ -97,7 +97,7 @@ func (r *OBClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 func (r *OBClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.OBCluster{}).
-		Owns(&v1alpha1.OBZone{}).Owns(&v1alpha1.OBParameter{}).
+		Owns(&v1alpha1.OBZone{}).
 		WithEventFilter(preds).
 		Complete(r)
 }

--- a/internal/controller/obcluster_controller.go
+++ b/internal/controller/obcluster_controller.go
@@ -97,6 +97,7 @@ func (r *OBClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 func (r *OBClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.OBCluster{}).
+		Owns(&v1alpha1.OBZone{}).Owns(&v1alpha1.OBParameter{}).
 		WithEventFilter(preds).
 		Complete(r)
 }

--- a/internal/controller/obzone_controller.go
+++ b/internal/controller/obzone_controller.go
@@ -87,6 +87,7 @@ func (r *OBZoneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 func (r *OBZoneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.OBZone{}).
+		Owns(&v1alpha1.OBServer{}).
 		WithEventFilter(preds).
 		Complete(r)
 }

--- a/internal/resource/obtenantbackuppolicy/obtenantbackuppolicy_manager.go
+++ b/internal/resource/obtenantbackuppolicy/obtenantbackuppolicy_manager.go
@@ -168,7 +168,7 @@ func (m *ObTenantBackupPolicyManager) UpdateStatus() error {
 		m.BackupPolicy.Status.OperationContext = nil
 	} else if !m.BackupPolicy.Spec.Suspend && m.BackupPolicy.Status.Status == constants.BackupPolicyStatusPaused {
 		m.BackupPolicy.Status.Status = constants.BackupPolicyStatusResuming
-	} else if m.IsDeleting() && m.BackupPolicy.Status.Status == constants.BackupPolicyStatusRunning {
+	} else if m.IsDeleting() && (m.BackupPolicy.Status.Status == constants.BackupPolicyStatusRunning || m.BackupPolicy.Status.Status == constants.BackupPolicyStatusPaused) {
 		m.BackupPolicy.Status.Status = constants.BackupPolicyStatusDeleting
 		m.BackupPolicy.Status.OperationContext = nil
 	} else if m.BackupPolicy.Status.Status == constants.BackupPolicyStatusRunning {


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

1. Fixed the bug that backup policy cannot be deleted in `paused` status
2. Added reconciliation for OBCluster and OBZone when sub-resource changes, closed #199 
3. Added necessary labels for tenant operation and tenant
4. Fixed the bug that backup policy uses tenantName in database instead of CR name of OBTenant in its labels
