### PR TITLE
Fix bugs found in testings for OBResourceRescue

### DIFF
--- a/internal/dashboard/generated/bindata/bindata.go
+++ b/internal/dashboard/generated/bindata/bindata.go
@@ -200,11 +200,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error

--- a/pkg/task/task_manager.go
+++ b/pkg/task/task_manager.go
@@ -50,6 +50,9 @@ func taskManagerInit() {
 func runTask(f tasktypes.TaskFunc, ch chan<- *tasktypes.TaskResult, tokens chan struct{}) {
 	defer func() {
 		if r := recover(); r != nil {
+			if ch == nil {
+				return
+			}
 			ch <- &tasktypes.TaskResult{
 				Status: taskstatus.Failed,
 				Error:  errors.Errorf("Observed a panic: %v, stacktrace: %s", r, string(debug.Stack())),

--- a/pkg/task/task_manager.go
+++ b/pkg/task/task_manager.go
@@ -50,15 +50,13 @@ func taskManagerInit() {
 func runTask(f tasktypes.TaskFunc, ch chan<- *tasktypes.TaskResult, tokens chan struct{}) {
 	defer func() {
 		if r := recover(); r != nil {
-			if ch == nil {
-				return
-			}
 			ch <- &tasktypes.TaskResult{
 				Status: taskstatus.Failed,
 				Error:  errors.Errorf("Observed a panic: %v, stacktrace: %s", r, string(debug.Stack())),
 			}
 		}
 		<-tokens
+		close(ch)
 	}()
 
 	tokens <- struct{}{}
@@ -136,18 +134,21 @@ func (m *TaskManager) GetTaskResult(taskId tasktypes.TaskID) (*tasktypes.TaskRes
 			"Pool size", cap(m.tokens),
 		)
 	}
-	retChAny, exists := m.ResultMap.Load(taskId)
-	if !exists {
-		return nil, errors.Errorf("Task %s not exists", taskId)
-	}
-	retCh, ok := retChAny.(chan *tasktypes.TaskResult)
-	if !ok {
-		return nil, errors.Errorf("Task %s not exists", taskId)
-	}
 	result, exists := m.TaskResultCache.Load(taskId)
 	if !exists {
+		retChAny, exists := m.ResultMap.Load(taskId)
+		if !exists {
+			return nil, errors.Errorf("Task %s not exists", taskId)
+		}
+		retCh, ok := retChAny.(chan *tasktypes.TaskResult)
+		if !ok {
+			return nil, errors.Errorf("Task %s not exists", taskId)
+		}
 		select {
-		case result := <-retCh:
+		case result, ok := <-retCh:
+			if !ok {
+				return nil, errors.Errorf("Result channel of task %s was closed", taskId)
+			}
 			m.TaskResultCache.Store(taskId, result)
 			return result, nil
 		default:
@@ -162,11 +163,10 @@ func (m *TaskManager) CleanTaskResult(taskId tasktypes.TaskID) error {
 	if !exists {
 		return nil
 	}
-	retCh, ok := retChAny.(chan *tasktypes.TaskResult)
+	_, ok := retChAny.(chan *tasktypes.TaskResult)
 	if !ok {
 		return nil
 	}
-	close(retCh)
 	m.ResultMap.Delete(taskId)
 	m.TaskResultCache.Delete(taskId)
 

--- a/pkg/task/task_manager.go
+++ b/pkg/task/task_manager.go
@@ -159,12 +159,8 @@ func (m *TaskManager) GetTaskResult(taskId tasktypes.TaskID) (*tasktypes.TaskRes
 }
 
 func (m *TaskManager) CleanTaskResult(taskId tasktypes.TaskID) error {
-	retChAny, exists := m.ResultMap.Load(taskId)
+	_, exists := m.ResultMap.Load(taskId)
 	if !exists {
-		return nil
-	}
-	_, ok := retChAny.(chan *tasktypes.TaskResult)
-	if !ok {
 		return nil
 	}
 	m.ResultMap.Delete(taskId)


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

1. Bare `0` could not be set in unstructured type. Set an int64 zero instead.
2. Refined logic of task manager by closing task result channel from sender end.
