### PR TITLE
fix(statistic): add tenant statistic and update cluster statistic

### DIFF
--- a/internal/dashboard/business/oceanbase/obcluster.go
+++ b/internal/dashboard/business/oceanbase/obcluster.go
@@ -546,8 +546,8 @@ func DeleteOBCluster(ctx context.Context, obclusterIdentity *param.K8sObjectIden
 	return oceanbase.DeleteOBCluster(ctx, obclusterIdentity.Namespace, obclusterIdentity.Name)
 }
 
-func GetOBClusterStatistic(ctx context.Context) ([]*response.OBClusterStastistic, error) {
-	statisticResult := make([]*response.OBClusterStastistic, 0)
+func GetOBClusterStatistic(ctx context.Context) ([]response.OBClusterStastistic, error) {
+	statisticResult := make([]response.OBClusterStastistic, 0)
 	obclusterList, err := oceanbase.ListAllOBClusters(ctx)
 	if err != nil {
 		return statisticResult, errors.Wrap(err, "failed to list obclusters")
@@ -571,16 +571,16 @@ func GetOBClusterStatistic(ctx context.Context) ([]*response.OBClusterStastistic
 		}
 	}
 	statisticResult = append(statisticResult,
-		&response.OBClusterStastistic{
+		response.OBClusterStastistic{
 			Status: StatusRunning,
 			Count:  runningCount,
-		}, &response.OBClusterStastistic{
+		}, response.OBClusterStastistic{
 			Status: StatusDeleting,
 			Count:  deletingCount,
-		}, &response.OBClusterStastistic{
+		}, response.OBClusterStastistic{
 			Status: StatusOperating,
 			Count:  operatingCount,
-		}, &response.OBClusterStastistic{
+		}, response.OBClusterStastistic{
 			Status: StatusFailed,
 			Count:  failedCount,
 		})

--- a/internal/dashboard/business/oceanbase/obcluster.go
+++ b/internal/dashboard/business/oceanbase/obcluster.go
@@ -41,6 +41,7 @@ const (
 	StatusDeleting  = "deleting"
 	StatusRunning   = "running"
 	StatusOperating = "operating"
+	StatusFailed    = "failed"
 )
 
 func convertStatus(detailedStatus string) string {
@@ -57,6 +58,8 @@ func getStatisticStatus(obcluster *v1alpha1.OBCluster) string {
 		return StatusDeleting
 	} else if obcluster.Status.Status == StatusRunning {
 		return StatusRunning
+	} else if obcluster.Status.Status == clusterstatus.Failed {
+		return StatusFailed
 	} else {
 		return StatusOperating
 	}
@@ -543,28 +546,43 @@ func DeleteOBCluster(ctx context.Context, obclusterIdentity *param.K8sObjectIden
 	return oceanbase.DeleteOBCluster(ctx, obclusterIdentity.Namespace, obclusterIdentity.Name)
 }
 
-func GetOBClusterStatistic(ctx context.Context) ([]response.OBClusterStastistic, error) {
-	statisticResult := make([]response.OBClusterStastistic, 0)
+func GetOBClusterStatistic(ctx context.Context) ([]*response.OBClusterStastistic, error) {
+	statisticResult := make([]*response.OBClusterStastistic, 0)
 	obclusterList, err := oceanbase.ListAllOBClusters(ctx)
 	if err != nil {
 		return statisticResult, errors.Wrap(err, "failed to list obclusters")
 	}
-	statusMap := make(map[string]int)
+	var (
+		runningCount   int
+		deletingCount  int
+		operatingCount int
+		failedCount    int
+	)
 	for _, obcluster := range obclusterList.Items {
-		statisticStatus := getStatisticStatus(&obcluster)
-		cnt, found := statusMap[statisticStatus]
-		if found {
-			cnt++
-		} else {
-			cnt = 1
+		switch getStatisticStatus(&obcluster) {
+		case StatusRunning:
+			runningCount++
+		case StatusDeleting:
+			deletingCount++
+		case StatusOperating:
+			operatingCount++
+		case StatusFailed:
+			failedCount++
 		}
-		statusMap[statisticStatus] = cnt
 	}
-	for status, count := range statusMap {
-		statisticResult = append(statisticResult, response.OBClusterStastistic{
-			Status: status,
-			Count:  count,
+	statisticResult = append(statisticResult,
+		&response.OBClusterStastistic{
+			Status: StatusRunning,
+			Count:  runningCount,
+		}, &response.OBClusterStastistic{
+			Status: StatusDeleting,
+			Count:  deletingCount,
+		}, &response.OBClusterStastistic{
+			Status: StatusOperating,
+			Count:  operatingCount,
+		}, &response.OBClusterStastistic{
+			Status: StatusFailed,
+			Count:  failedCount,
 		})
-	}
 	return statisticResult, nil
 }

--- a/internal/dashboard/business/oceanbase/obtenant.go
+++ b/internal/dashboard/business/oceanbase/obtenant.go
@@ -121,7 +121,7 @@ func buildOBTenantApiType(nn types.NamespacedName, p *param.CreateOBTenantParam)
 			t.Spec.Source.Restore.BakDataSource.Type = apitypes.BackupDestType(p.Source.Restore.Type)
 			t.Spec.Source.Restore.BakDataSource.Path = p.Source.Restore.BakDataSource
 
-			if p.Source.Restore.Until != nil {
+			if p.Source.Restore.Until != nil && !p.Source.Restore.Until.Unlimited {
 				t.Spec.Source.Restore.Until.Timestamp = p.Source.Restore.Until.Timestamp
 			} else {
 				t.Spec.Source.Restore.Until.Unlimited = true

--- a/internal/dashboard/business/oceanbase/obtenant.go
+++ b/internal/dashboard/business/oceanbase/obtenant.go
@@ -505,8 +505,8 @@ func PatchTenant(ctx context.Context, nn types.NamespacedName, p *param.PatchTen
 
 // GetOBTenantStatistics returns the statistics of all tenants
 // Including the number of tenants in four status: running, deleting, operating, failed
-func GetOBTenantStatistics(ctx context.Context) ([]*response.OBTenantStatistic, error) {
-	stats := []*response.OBTenantStatistic{}
+func GetOBTenantStatistics(ctx context.Context) ([]response.OBTenantStatistic, error) {
+	stats := []response.OBTenantStatistic{}
 	tenantList, err := oceanbase.ListAllOBTenants(ctx, v1.ListOptions{})
 	if err != nil {
 		return nil, oberr.Wrap(err, oberr.ErrInternal, "failed to list tenants")
@@ -524,16 +524,16 @@ func GetOBTenantStatistics(ctx context.Context) ([]*response.OBTenantStatistic, 
 			operatingCount++
 		}
 	}
-	stats = append(stats, &response.OBTenantStatistic{
+	stats = append(stats, response.OBTenantStatistic{
 		Status: tenantstatus.Running,
 		Count:  runningCount,
-	}, &response.OBTenantStatistic{
+	}, response.OBTenantStatistic{
 		Status: tenantstatus.DeletingTenant,
 		Count:  deletingCount,
-	}, &response.OBTenantStatistic{
+	}, response.OBTenantStatistic{
 		Status: "operating",
 		Count:  operatingCount,
-	}, &response.OBTenantStatistic{
+	}, response.OBTenantStatistic{
 		Status: tenantstatus.Failed,
 		Count:  failedCount,
 	})

--- a/internal/dashboard/business/oceanbase/obtenant.go
+++ b/internal/dashboard/business/oceanbase/obtenant.go
@@ -25,6 +25,7 @@ import (
 	apiconst "github.com/oceanbase/ob-operator/api/constants"
 	apitypes "github.com/oceanbase/ob-operator/api/types"
 	"github.com/oceanbase/ob-operator/api/v1alpha1"
+	"github.com/oceanbase/ob-operator/internal/const/status/tenantstatus"
 	"github.com/oceanbase/ob-operator/internal/dashboard/model/param"
 	"github.com/oceanbase/ob-operator/internal/dashboard/model/response"
 	"github.com/oceanbase/ob-operator/internal/oceanbase"
@@ -500,4 +501,41 @@ func PatchTenant(ctx context.Context, nn types.NamespacedName, p *param.PatchTen
 		return nil, err
 	}
 	return buildDetailFromApiType(tenant), nil
+}
+
+// GetOBTenantStatistics returns the statistics of all tenants
+// Including the number of tenants in four status: running, deleting, operating, failed
+func GetOBTenantStatistics(ctx context.Context) ([]*response.OBTenantStatistic, error) {
+	stats := []*response.OBTenantStatistic{}
+	tenantList, err := oceanbase.ListAllOBTenants(ctx, v1.ListOptions{})
+	if err != nil {
+		return nil, oberr.Wrap(err, oberr.ErrInternal, "failed to list tenants")
+	}
+	var runningCount, deletingCount, operatingCount, failedCount int
+	for _, tenant := range tenantList.Items {
+		switch tenant.Status.Status {
+		case tenantstatus.Running:
+			runningCount++
+		case tenantstatus.DeletingTenant:
+			deletingCount++
+		case tenantstatus.Failed, tenantstatus.RestoreFailed:
+			failedCount++
+		default:
+			operatingCount++
+		}
+	}
+	stats = append(stats, &response.OBTenantStatistic{
+		Status: tenantstatus.Running,
+		Count:  runningCount,
+	}, &response.OBTenantStatistic{
+		Status: tenantstatus.DeletingTenant,
+		Count:  deletingCount,
+	}, &response.OBTenantStatistic{
+		Status: "operating",
+		Count:  operatingCount,
+	}, &response.OBTenantStatistic{
+		Status: tenantstatus.Failed,
+		Count:  failedCount,
+	})
+	return stats, nil
 }

--- a/internal/dashboard/generated/swagger/docs.go
+++ b/internal/dashboard/generated/swagger/docs.go
@@ -1374,6 +1374,68 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/obtenants/statistic": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "List statistics information of tenants",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Obtenant"
+                ],
+                "summary": "List statistics information of tenants",
+                "operationId": "GetOBTenantStatistic",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/response.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/response.OBTenantStatistic"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/response.APIResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/response.APIResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.APIResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/obtenants/{namespace}/{name}": {
             "get": {
                 "security": [
@@ -2319,6 +2381,46 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "common.AffinitySpec": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/common.AffinityType"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "common.AffinityType": {
+            "type": "string",
+            "enum": [
+                "NODE",
+                "POD",
+                "POD_ANTI"
+            ],
+            "x-enum-varnames": [
+                "NodeAffinityType",
+                "PodAffinityType",
+                "PodAntiAffinityType"
+            ]
+        },
+        "common.ClusterMode": {
+            "type": "string",
+            "enum": [
+                "NORMAL",
+                "STANDALONE",
+                "SERVICE"
+            ],
+            "x-enum-varnames": [
+                "ClusterModeNormal",
+                "ClusterModeStandalone",
+                "ClusterModeService"
+            ]
+        },
         "common.KVPair": {
             "type": "object",
             "properties": {
@@ -2459,6 +2561,9 @@ const docTemplate = `{
                 },
                 "clusterName": {
                     "type": "string"
+                },
+                "mode": {
+                    "$ref": "#/definitions/common.ClusterMode"
                 },
                 "monitor": {
                     "$ref": "#/definitions/param.MonitorSpec"
@@ -2862,6 +2967,12 @@ const docTemplate = `{
         "param.ZoneTopology": {
             "type": "object",
             "properties": {
+                "affinities": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.AffinitySpec"
+                    }
+                },
                 "nodeSelector": {
                     "type": "array",
                     "items": {
@@ -2870,6 +2981,12 @@ const docTemplate = `{
                 },
                 "replicas": {
                     "type": "integer"
+                },
+                "tolerations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.KVPair"
+                    }
                 },
                 "zone": {
                     "type": "string"
@@ -3228,6 +3345,28 @@ const docTemplate = `{
                 }
             }
         },
+        "response.MonitorSpec": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "string"
+                },
+                "resource": {
+                    "$ref": "#/definitions/common.ResourceSpec"
+                }
+            }
+        },
+        "response.NFSVolumeSpec": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                }
+            }
+        },
         "response.Namespace": {
             "type": "object",
             "properties": {
@@ -3242,6 +3381,9 @@ const docTemplate = `{
         "response.OBCluster": {
             "type": "object",
             "properties": {
+                "backupVolume": {
+                    "$ref": "#/definitions/response.NFSVolumeSpec"
+                },
                 "clusterId": {
                     "type": "integer"
                 },
@@ -3257,10 +3399,25 @@ const docTemplate = `{
                 "metrics": {
                     "$ref": "#/definitions/response.OBMetrics"
                 },
+                "mode": {
+                    "$ref": "#/definitions/common.ClusterMode"
+                },
+                "monitor": {
+                    "$ref": "#/definitions/response.MonitorSpec"
+                },
                 "name": {
                     "type": "string"
                 },
                 "namespace": {
+                    "type": "string"
+                },
+                "parameters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.KVPair"
+                    }
+                },
+                "rootPasswordSecret": {
                     "type": "string"
                 },
                 "status": {
@@ -3484,9 +3641,26 @@ const docTemplate = `{
                 }
             }
         },
+        "response.OBTenantStatistic": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
         "response.OBZone": {
             "type": "object",
             "properties": {
+                "affinities": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.AffinitySpec"
+                    }
+                },
                 "name": {
                     "type": "string"
                 },
@@ -3516,6 +3690,12 @@ const docTemplate = `{
                 },
                 "statusDetail": {
                     "type": "string"
+                },
+                "tolerations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.KVPair"
+                    }
                 },
                 "zone": {
                     "type": "string"

--- a/internal/dashboard/generated/swagger/swagger.json
+++ b/internal/dashboard/generated/swagger/swagger.json
@@ -1367,6 +1367,68 @@
                 }
             }
         },
+        "/api/v1/obtenants/statistic": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "List statistics information of tenants",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Obtenant"
+                ],
+                "summary": "List statistics information of tenants",
+                "operationId": "GetOBTenantStatistic",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/response.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/response.OBTenantStatistic"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/response.APIResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/response.APIResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.APIResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/obtenants/{namespace}/{name}": {
             "get": {
                 "security": [
@@ -2312,6 +2374,46 @@
         }
     },
     "definitions": {
+        "common.AffinitySpec": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/common.AffinityType"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "common.AffinityType": {
+            "type": "string",
+            "enum": [
+                "NODE",
+                "POD",
+                "POD_ANTI"
+            ],
+            "x-enum-varnames": [
+                "NodeAffinityType",
+                "PodAffinityType",
+                "PodAntiAffinityType"
+            ]
+        },
+        "common.ClusterMode": {
+            "type": "string",
+            "enum": [
+                "NORMAL",
+                "STANDALONE",
+                "SERVICE"
+            ],
+            "x-enum-varnames": [
+                "ClusterModeNormal",
+                "ClusterModeStandalone",
+                "ClusterModeService"
+            ]
+        },
         "common.KVPair": {
             "type": "object",
             "properties": {
@@ -2452,6 +2554,9 @@
                 },
                 "clusterName": {
                     "type": "string"
+                },
+                "mode": {
+                    "$ref": "#/definitions/common.ClusterMode"
                 },
                 "monitor": {
                     "$ref": "#/definitions/param.MonitorSpec"
@@ -2855,6 +2960,12 @@
         "param.ZoneTopology": {
             "type": "object",
             "properties": {
+                "affinities": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.AffinitySpec"
+                    }
+                },
                 "nodeSelector": {
                     "type": "array",
                     "items": {
@@ -2863,6 +2974,12 @@
                 },
                 "replicas": {
                     "type": "integer"
+                },
+                "tolerations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.KVPair"
+                    }
                 },
                 "zone": {
                     "type": "string"
@@ -3221,6 +3338,28 @@
                 }
             }
         },
+        "response.MonitorSpec": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "string"
+                },
+                "resource": {
+                    "$ref": "#/definitions/common.ResourceSpec"
+                }
+            }
+        },
+        "response.NFSVolumeSpec": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                }
+            }
+        },
         "response.Namespace": {
             "type": "object",
             "properties": {
@@ -3235,6 +3374,9 @@
         "response.OBCluster": {
             "type": "object",
             "properties": {
+                "backupVolume": {
+                    "$ref": "#/definitions/response.NFSVolumeSpec"
+                },
                 "clusterId": {
                     "type": "integer"
                 },
@@ -3250,10 +3392,25 @@
                 "metrics": {
                     "$ref": "#/definitions/response.OBMetrics"
                 },
+                "mode": {
+                    "$ref": "#/definitions/common.ClusterMode"
+                },
+                "monitor": {
+                    "$ref": "#/definitions/response.MonitorSpec"
+                },
                 "name": {
                     "type": "string"
                 },
                 "namespace": {
+                    "type": "string"
+                },
+                "parameters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.KVPair"
+                    }
+                },
+                "rootPasswordSecret": {
                     "type": "string"
                 },
                 "status": {
@@ -3477,9 +3634,26 @@
                 }
             }
         },
+        "response.OBTenantStatistic": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
         "response.OBZone": {
             "type": "object",
             "properties": {
+                "affinities": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.AffinitySpec"
+                    }
+                },
                 "name": {
                     "type": "string"
                 },
@@ -3509,6 +3683,12 @@
                 },
                 "statusDetail": {
                     "type": "string"
+                },
+                "tolerations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.KVPair"
+                    }
                 },
                 "zone": {
                     "type": "string"

--- a/internal/dashboard/generated/swagger/swagger.yaml
+++ b/internal/dashboard/generated/swagger/swagger.yaml
@@ -1,5 +1,34 @@
 basePath: /api/v1
 definitions:
+  common.AffinitySpec:
+    properties:
+      key:
+        type: string
+      type:
+        $ref: '#/definitions/common.AffinityType'
+      value:
+        type: string
+    type: object
+  common.AffinityType:
+    enum:
+    - NODE
+    - POD
+    - POD_ANTI
+    type: string
+    x-enum-varnames:
+    - NodeAffinityType
+    - PodAffinityType
+    - PodAntiAffinityType
+  common.ClusterMode:
+    enum:
+    - NORMAL
+    - STANDALONE
+    - SERVICE
+    type: string
+    x-enum-varnames:
+    - ClusterModeNormal
+    - ClusterModeStandalone
+    - ClusterModeService
   common.KVPair:
     properties:
       key:
@@ -100,6 +129,8 @@ definitions:
         type: integer
       clusterName:
         type: string
+      mode:
+        $ref: '#/definitions/common.ClusterMode'
       monitor:
         $ref: '#/definitions/param.MonitorSpec'
       name:
@@ -373,12 +404,20 @@ definitions:
     type: object
   param.ZoneTopology:
     properties:
+      affinities:
+        items:
+          $ref: '#/definitions/common.AffinitySpec'
+        type: array
       nodeSelector:
         items:
           $ref: '#/definitions/common.KVPair'
         type: array
       replicas:
         type: integer
+      tolerations:
+        items:
+          $ref: '#/definitions/common.KVPair'
+        type: array
       zone:
         type: string
     type: object
@@ -619,6 +658,20 @@ definitions:
       value:
         type: number
     type: object
+  response.MonitorSpec:
+    properties:
+      image:
+        type: string
+      resource:
+        $ref: '#/definitions/common.ResourceSpec'
+    type: object
+  response.NFSVolumeSpec:
+    properties:
+      address:
+        type: string
+      path:
+        type: string
+    type: object
   response.Namespace:
     properties:
       namespace:
@@ -628,6 +681,8 @@ definitions:
     type: object
   response.OBCluster:
     properties:
+      backupVolume:
+        $ref: '#/definitions/response.NFSVolumeSpec'
       clusterId:
         type: integer
       clusterName:
@@ -638,9 +693,19 @@ definitions:
         type: string
       metrics:
         $ref: '#/definitions/response.OBMetrics'
+      mode:
+        $ref: '#/definitions/common.ClusterMode'
+      monitor:
+        $ref: '#/definitions/response.MonitorSpec'
       name:
         type: string
       namespace:
+        type: string
+      parameters:
+        items:
+          $ref: '#/definitions/common.KVPair'
+        type: array
+      rootPasswordSecret:
         type: string
       status:
         type: string
@@ -795,8 +860,19 @@ definitions:
       zone:
         type: string
     type: object
+  response.OBTenantStatistic:
+    properties:
+      count:
+        type: integer
+      status:
+        type: string
+    type: object
   response.OBZone:
     properties:
+      affinities:
+        items:
+          $ref: '#/definitions/common.AffinitySpec'
+        type: array
       name:
         type: string
       namespace:
@@ -817,6 +893,10 @@ definitions:
         type: string
       statusDetail:
         type: string
+      tolerations:
+        items:
+          $ref: '#/definitions/common.KVPair'
+        type: array
       zone:
         type: string
     type: object
@@ -2306,6 +2386,43 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Upgrade tenant compatibility version of specific tenant
+      tags:
+      - Obtenant
+  /api/v1/obtenants/statistic:
+    get:
+      consumes:
+      - application/json
+      description: List statistics information of tenants
+      operationId: GetOBTenantStatistic
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/response.APIResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/response.OBTenantStatistic'
+                  type: array
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/response.APIResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/response.APIResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/response.APIResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: List statistics information of tenants
       tags:
       - Obtenant
 securityDefinitions:

--- a/internal/dashboard/handler/obcluster_handler.go
+++ b/internal/dashboard/handler/obcluster_handler.go
@@ -34,7 +34,7 @@ import (
 // @Failure 401 object response.APIResponse
 // @Failure 500 object response.APIResponse
 // @Router /api/v1/obclusters/statistic [GET]
-func GetOBClusterStatistic(c *gin.Context) ([]*response.OBClusterStastistic, error) {
+func GetOBClusterStatistic(c *gin.Context) ([]response.OBClusterStastistic, error) {
 	// return mock data
 	obclusterStastics, err := oceanbase.GetOBClusterStatistic(c)
 	if err != nil {

--- a/internal/dashboard/handler/obcluster_handler.go
+++ b/internal/dashboard/handler/obcluster_handler.go
@@ -34,7 +34,7 @@ import (
 // @Failure 401 object response.APIResponse
 // @Failure 500 object response.APIResponse
 // @Router /api/v1/obclusters/statistic [GET]
-func GetOBClusterStatistic(c *gin.Context) ([]response.OBClusterStastistic, error) {
+func GetOBClusterStatistic(c *gin.Context) ([]*response.OBClusterStastistic, error) {
 	// return mock data
 	obclusterStastics, err := oceanbase.GetOBClusterStatistic(c)
 	if err != nil {

--- a/internal/dashboard/handler/obtenant_handler.go
+++ b/internal/dashboard/handler/obtenant_handler.go
@@ -526,3 +526,23 @@ func ListBackupJobs(c *gin.Context) ([]*response.BackupJob, error) {
 	}
 	return jobs, nil
 }
+
+// @ID GetOBTenantStatistic
+// @Tags Obtenant
+// @Summary List statistics information of tenants
+// @Description List statistics information of tenants
+// @Accept application/json
+// @Produce application/json
+// @Success 200 object response.APIResponse{data=[]response.OBTenantStatistic}
+// @Failure 400 object response.APIResponse
+// @Failure 401 object response.APIResponse
+// @Failure 500 object response.APIResponse
+// @Router /api/v1/obtenants/statistic [GET]
+// @Security ApiKeyAuth
+func GetOBTenantStatistic(c *gin.Context) ([]*response.OBTenantStatistic, error) {
+	tenants, err := oceanbase.GetOBTenantStatistics(c)
+	if err != nil {
+		return nil, err
+	}
+	return tenants, nil
+}

--- a/internal/dashboard/handler/obtenant_handler.go
+++ b/internal/dashboard/handler/obtenant_handler.go
@@ -539,7 +539,7 @@ func ListBackupJobs(c *gin.Context) ([]*response.BackupJob, error) {
 // @Failure 500 object response.APIResponse
 // @Router /api/v1/obtenants/statistic [GET]
 // @Security ApiKeyAuth
-func GetOBTenantStatistic(c *gin.Context) ([]*response.OBTenantStatistic, error) {
+func GetOBTenantStatistic(c *gin.Context) ([]response.OBTenantStatistic, error) {
 	tenants, err := oceanbase.GetOBTenantStatistics(c)
 	if err != nil {
 		return nil, err

--- a/internal/dashboard/model/response/obtenant.go
+++ b/internal/dashboard/model/response/obtenant.go
@@ -60,3 +60,5 @@ type RestoreSource struct {
 	BakEncryptionSecret string `json:"bakEncryptionSecret,omitempty"`
 	Until               string `json:"until,omitempty"`
 }
+
+type OBTenantStatistic OBClusterStastistic

--- a/internal/dashboard/router/v1/obtenant_router.go
+++ b/internal/dashboard/router/v1/obtenant_router.go
@@ -33,4 +33,5 @@ func InitOBTenantRoutes(g *gin.RouterGroup) {
 	g.PATCH("/obtenants/:namespace/:name/backupPolicy", h.Wrap(h.UpdateBackupPolicy))
 	g.DELETE("/obtenants/:namespace/:name/backupPolicy", h.Wrap(h.DeleteBackupPolicy))
 	g.GET("/obtenants/:namespace/:name/backup/:type/jobs", h.Wrap(h.ListBackupJobs))
+	g.GET("/obtenants/statistic", h.Wrap(h.GetOBTenantStatistic))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

1. Added status statistic API for tenants.
2. Updated status statistic API of clusters which now returns all four status even though the count is `0`.
