### PR TITLE
feat:Add minimum configuration to the observer

### DIFF
--- a/ui/src/components/InputNumber/index.tsx
+++ b/ui/src/components/InputNumber/index.tsx
@@ -1,0 +1,5 @@
+import { InputNumber as AntdInputNumber } from 'antd';
+
+export default function InputNumber(props: any) {
+  return <AntdInputNumber min={0} {...props} />;
+}

--- a/ui/src/components/TopoComponent/index.tsx
+++ b/ui/src/components/TopoComponent/index.tsx
@@ -223,7 +223,7 @@ export default function TopoComponent({
   useUpdateEffect(() => {
     let checkStatusTimer: NodeJS.Timer;
     //polling
-    if (originTopoData.topoData.status === 'operating') {
+    if (originTopoData.topoData.status !== 'running') {
       if (!operateDisable) setOperateDisable(true);
       checkStatusTimer = setInterval(() => {
         getTopoData({ ns, name, useFor: 'topo', tenantReplicas });

--- a/ui/src/constants/index.ts
+++ b/ui/src/constants/index.ts
@@ -11,7 +11,7 @@ import zoneDeleting from '@/assets/zone/deleting.svg';
 import zoneOperating from '@/assets/zone/operating.svg';
 import zoneRunning from '@/assets/zone/running.svg';
 
-//统一状态常量和颜色
+//Unify status constants and colors
 const STATUS = ['running', 'deleting', 'operating'];
 const COLOR_MAP = new Map([
   ['running', 'geekblue'],
@@ -40,23 +40,35 @@ const BADGE_IMG_MAP = new Map([
   ['operating', badgeOperating],
 ]);
 
+const REFRESH_TENANT_TIME = 5000;
+
 const REFRESH_CLUSTER_TIME = 10000;
-// 性能监控自动刷新时间 15s
+// Monitor automatic refresh interval 15s
 const REFRESH_FREQUENCY = 15;
-// 监控点位数量
+// Number of monitoring points
 const POINT_NUMBER = 15;
 
 const SUFFIX_UNIT = 'GB';
 
+const MINIMAL_CONFIG = {
+  cpu: 2,
+  memory: 10,
+  data: 30,
+  log: 30,
+  redoLog: 30,
+};
+
 export {
-  POINT_NUMBER,
-  REFRESH_CLUSTER_TIME,
-  REFRESH_FREQUENCY,
-  SUFFIX_UNIT,
   BADGE_IMG_MAP,
   CLUSTER_IMG_MAP,
   COLOR_MAP,
+  MINIMAL_CONFIG,
+  POINT_NUMBER,
+  REFRESH_CLUSTER_TIME,
+  REFRESH_FREQUENCY,
+  REFRESH_TENANT_TIME,
   SERVER_IMG_MAP,
   STATUS,
+  SUFFIX_UNIT,
   ZONE_IMG_MAP,
 };

--- a/ui/src/i18n/strings/en-US.json
+++ b/ui/src/i18n/strings/en-US.json
@@ -562,5 +562,14 @@
   "Dashboard.Detail.Backup.JobTable.Path": "Path",
   "Dashboard.Detail.Backup.JobTable.ResourceStatus": "Resource status",
   "Dashboard.Detail.Backup.JobTable.TaskStatus": "Task Status",
-  "Dashboard.Tenant.Detail.PerformanceMonitoring": "Performance monitoring"
+  "Dashboard.Tenant.Detail.PerformanceMonitoring": "Performance monitoring",
+  "Dashboard.Cluster.New.Observer.MinimumSpecificationConfiguration": "Minimum specification configuration",
+  "Dashboard.pages.Overview.OverviewStatus.Running": "Running",
+  "Dashboard.pages.Overview.OverviewStatus.Deleting": "Deleting",
+  "Dashboard.pages.Overview.OverviewStatus.InOperation": "In operation",
+  "Dashboard.pages.Overview.OverviewStatus.AnErrorHasOccurred": "An error has occurred.",
+  "Dashboard.Tenant.New.TenantSource.NfsTypeSeePathFormat": "NFS type, see path format: path/to/dir",
+  "Dashboard.Tenant.New.TenantSource.OssTypeForMoreInformation": "OSS type. For more information, see oss:// bucket/dir? host=xxx",
+  "Dashboard.src.utils.helper.OceanbaseCluster": "OceanBase cluster",
+  "Dashboard.src.utils.helper.OceanbaseTenants": "OceanBase tenants"
 }

--- a/ui/src/i18n/strings/zh-CN.json
+++ b/ui/src/i18n/strings/zh-CN.json
@@ -562,5 +562,14 @@
   "Dashboard.Detail.Backup.JobTable.Path": "路径",
   "Dashboard.Detail.Backup.JobTable.ResourceStatus": "资源状态",
   "Dashboard.Detail.Backup.JobTable.TaskStatus": "任务状态",
-  "Dashboard.Tenant.Detail.PerformanceMonitoring": "性能监控"
+  "Dashboard.Tenant.Detail.PerformanceMonitoring": "性能监控",
+  "Dashboard.Cluster.New.Observer.MinimumSpecificationConfiguration": "最小规格配置",
+  "Dashboard.pages.Overview.OverviewStatus.Running": "运行中",
+  "Dashboard.pages.Overview.OverviewStatus.Deleting": "删除中",
+  "Dashboard.pages.Overview.OverviewStatus.InOperation": "操作中",
+  "Dashboard.pages.Overview.OverviewStatus.AnErrorHasOccurred": "已出错",
+  "Dashboard.Tenant.New.TenantSource.NfsTypeSeePathFormat": "NFS 类型，参考路径格式：path/to/dir",
+  "Dashboard.Tenant.New.TenantSource.OssTypeForMoreInformation": "OSS 类型，参考路径格式：oss://bucket/dir?host=xxx",
+  "Dashboard.src.utils.helper.OceanbaseCluster": "OceanBase集群",
+  "Dashboard.src.utils.helper.OceanbaseTenants": "OceanBase租户"
 }

--- a/ui/src/pages/Cluster/Detail/Overview/index.tsx
+++ b/ui/src/pages/Cluster/Detail/Overview/index.tsx
@@ -21,7 +21,7 @@ const ClusterOverview: React.FC = () => {
     useState<boolean>(false);
   const [[ns, name]] = useState(getNSName());
   const chooseZoneName = useRef<string>('');
-  const timerRef = useRef<NodeJS.Timeout>()
+  const timerRef = useRef<NodeJS.Timeout>();
   const [chooseServerNum, setChooseServerNum] = useState<number>(1);
   //当前运维弹窗类型
   const modalType = useRef<API.ModalType>('addZone');

--- a/ui/src/pages/Cluster/New/Observer.tsx
+++ b/ui/src/pages/Cluster/New/Observer.tsx
@@ -1,9 +1,19 @@
 import { intl } from '@/utils/intl';
-import { Card, Col, Form, Input, InputNumber, Row, Tooltip } from 'antd';
+import {
+  Button,
+  Card,
+  Col,
+  Form,
+  Input,
+  InputNumber,
+  Row,
+  Tooltip,
+} from 'antd';
 
 import ClassSelect from '@/components/ClassSelect';
-import { SUFFIX_UNIT } from '@/constants';
+import { MINIMAL_CONFIG, SUFFIX_UNIT } from '@/constants';
 import { MIRROR_SERVER } from '@/constants/doc';
+import { clone } from 'lodash';
 import styles from './index.less';
 
 const observerToolTipText = intl.formatMessage({
@@ -35,9 +45,45 @@ export default function Observer({ storageClasses, form }: any) {
     );
   };
 
+  const setMinimalConfiguration = () => {
+    let originObserver = clone(form.getFieldsValue());
+    form.setFieldsValue({
+      ...originObserver,
+      observer: {
+        ...originObserver.observer,
+        resource: {
+          cpu: MINIMAL_CONFIG.cpu,
+          memory: MINIMAL_CONFIG.memory,
+        },
+        storage: {
+          ...originObserver.observer.storage,
+          data: {
+            size: MINIMAL_CONFIG.data,
+          },
+          log: {
+            size: MINIMAL_CONFIG.log,
+          },
+          redoLog: {
+            size: MINIMAL_CONFIG.redoLog,
+          },
+        },
+      },
+    });
+  };
+
   return (
     <Col span={24}>
-      <Card title="Observer">
+      <Card
+        title="Observer"
+        extra={
+          <Button type="primary" onClick={setMinimalConfiguration}>
+            {intl.formatMessage({
+              id: 'Dashboard.Cluster.New.Observer.MinimumSpecificationConfiguration',
+              defaultMessage: '最小规格配置',
+            })}
+          </Button>
+        }
+      >
         <Tooltip title={observerToolTipText}>
           <CustomItem
             style={{ width: '50%' }}
@@ -81,7 +127,7 @@ export default function Observer({ storageClasses, form }: any) {
                 name={['observer', 'resource', 'cpu']}
               >
                 <InputNumber
-                  min={2}
+                  min={MINIMAL_CONFIG.cpu}
                   placeholder={intl.formatMessage({
                     id: 'OBDashboard.Cluster.New.Observer.PleaseEnter',
                     defaultMessage: '请输入',
@@ -96,7 +142,7 @@ export default function Observer({ storageClasses, form }: any) {
                 name={['observer', 'resource', 'memory']}
               >
                 <InputNumber
-                  min={10}
+                  min={MINIMAL_CONFIG.memory}
                   addonAfter={SUFFIX_UNIT}
                   placeholder={intl.formatMessage({
                     id: 'OBDashboard.Cluster.New.Observer.PleaseEnter',
@@ -124,7 +170,7 @@ export default function Observer({ storageClasses, form }: any) {
                 name={['observer', 'storage', 'data', 'size']}
               >
                 <InputNumber
-                  min={30}
+                  min={MINIMAL_CONFIG.data}
                   addonAfter={SUFFIX_UNIT}
                   placeholder={intl.formatMessage({
                     id: 'OBDashboard.Cluster.New.Observer.PleaseEnter',
@@ -162,7 +208,7 @@ export default function Observer({ storageClasses, form }: any) {
                 name={['observer', 'storage', 'log', 'size']}
               >
                 <InputNumber
-                  min={30}
+                  min={MINIMAL_CONFIG.log}
                   addonAfter={SUFFIX_UNIT}
                   placeholder={intl.formatMessage({
                     id: 'OBDashboard.Cluster.New.Observer.PleaseEnter',
@@ -193,7 +239,7 @@ export default function Observer({ storageClasses, form }: any) {
                 name={['observer', 'storage', 'redoLog', 'size']}
               >
                 <InputNumber
-                  min={30}
+                  min={MINIMAL_CONFIG.redoLog}
                   addonAfter={SUFFIX_UNIT}
                   placeholder={intl.formatMessage({
                     id: 'OBDashboard.Cluster.New.Observer.PleaseEnter',

--- a/ui/src/pages/Overview/OverviewStatus.tsx
+++ b/ui/src/pages/Overview/OverviewStatus.tsx
@@ -1,6 +1,6 @@
 import { intl } from '@/utils/intl';
 import { useRequest } from 'ahooks';
-import { Badge,Card,Col,Row } from 'antd';
+import { Badge, Card, Col, Row } from 'antd';
 
 import clusterImg from '@/assets/cluster/running.svg';
 import tenantImg from '@/assets/tenant.svg';
@@ -9,8 +9,8 @@ import { getTenantStatisticReq } from '@/services/tenant';
 import styles from './index.less';
 
 export default function OverviewStatus() {
-  const { data:clusterStatisticRes } = useRequest(getClusterStatisticReq);
-  const { data:tenantStatisticRes } = useRequest(getTenantStatisticReq)
+  const { data: clusterStatisticRes } = useRequest(getClusterStatisticReq);
+  const { data: tenantStatisticRes } = useRequest(getTenantStatisticReq);
   const clusterHref = '/#/cluster';
   const tenantHref = '/#/tenant';
   const clusterStatistic = clusterStatisticRes?.data;
@@ -44,31 +44,46 @@ export default function OverviewStatus() {
   const getStatisticConfig = (statistic: API.StatisticData) => ({
     running: (
       <CustomBadge
-        text="运行中"
+        text={intl.formatMessage({
+          id: 'Dashboard.pages.Overview.OverviewStatus.Running',
+          defaultMessage: '运行中',
+        })}
         status="processing"
         type={statistic.type}
         count={statistic.running}
       />
     ),
+
     deleting: (
       <CustomBadge
-        text="删除中"
+        text={intl.formatMessage({
+          id: 'Dashboard.pages.Overview.OverviewStatus.Deleting',
+          defaultMessage: '删除中',
+        })}
         status="error"
         type={statistic.type}
         count={statistic.deleting}
       />
     ),
+
     operating: (
       <CustomBadge
-        text="操作中"
+        text={intl.formatMessage({
+          id: 'Dashboard.pages.Overview.OverviewStatus.InOperation',
+          defaultMessage: '操作中',
+        })}
         status="warning"
         type={statistic.type}
         count={statistic.operating}
       />
     ),
+
     failed: (
       <CustomBadge
-        text="已出错"
+        text={intl.formatMessage({
+          id: 'Dashboard.pages.Overview.OverviewStatus.AnErrorHasOccurred',
+          defaultMessage: '已出错',
+        })}
         status="default"
         type={statistic.type}
         count={statistic.failed}
@@ -78,53 +93,56 @@ export default function OverviewStatus() {
 
   return (
     <>
-      {clusterStatistic && tenantStatistic ?
-        [clusterStatistic,tenantStatistic].map((statistic, index) => {
-          return (
-            <Col
-              span={8}
-              className={styles.overviewStatusContainerx}
-              key={index}
-            >
-              <Card
-                className={styles.cardContent}
+      {clusterStatistic && tenantStatistic
+        ? [clusterStatistic, tenantStatistic].map((statistic, index) => {
+            return (
+              <Col
+                span={8}
+                className={styles.overviewStatusContainerx}
+                key={index}
               >
-                <Row>
-                  <Col
-                    span={4}
-                    style={{
-                      textAlign: 'center',
-                    }}
-                  >
-                    <img
-                      src={statistic.type === 'cluster' ? clusterImg : tenantImg}
-                      className={styles.imgContent}
-                      alt="svg"
-                    />
+                <Card className={styles.cardContent}>
+                  <Row>
+                    <Col
+                      span={4}
+                      style={{
+                        textAlign: 'center',
+                      }}
+                    >
+                      <img
+                        src={
+                          statistic.type === 'cluster' ? clusterImg : tenantImg
+                        }
+                        className={styles.imgContent}
+                        alt="svg"
+                      />
 
-                    <div className={styles.total}>
-                      <div className={styles.totalText}>{statistic.total}</div>
-                      <div className={styles.totalTitle}>
-                        {intl.formatMessage({
-                          id: 'dashboard.pages.Overview.OverviewStatus.TotalQuantity',
-                          defaultMessage: '总数量',
-                        })}
+                      <div className={styles.total}>
+                        <div className={styles.totalText}>
+                          {statistic.total}
+                        </div>
+                        <div className={styles.totalTitle}>
+                          {intl.formatMessage({
+                            id: 'dashboard.pages.Overview.OverviewStatus.TotalQuantity',
+                            defaultMessage: '总数量',
+                          })}
+                        </div>
                       </div>
-                    </div>
-                  </Col>
-                  <Col span={14} offset={6}>
-                    <div className={styles.name}>{statistic.name}</div>
-                    <div>
-                      {
-                        Object.keys(getStatisticConfig(statistic)).map((key)=>(getStatisticConfig(statistic)[key]))
-                      }
-                    </div>
-                  </Col>
-                </Row>
-              </Card>
-            </Col>
-          );
-        }) : null}
+                    </Col>
+                    <Col span={14} offset={6}>
+                      <div className={styles.name}>{statistic.name}</div>
+                      <div>
+                        {Object.keys(getStatisticConfig(statistic)).map(
+                          (key) => getStatisticConfig(statistic)[key],
+                        )}
+                      </div>
+                    </Col>
+                  </Row>
+                </Card>
+              </Col>
+            );
+          })
+        : null}
     </>
   );
 }

--- a/ui/src/pages/Tenant/New/BasicInfo.tsx
+++ b/ui/src/pages/Tenant/New/BasicInfo.tsx
@@ -1,6 +1,7 @@
 import PasswordInput from '@/components/PasswordInput';
 import { intl } from '@/utils/intl';
-import { Card, Col, Form, Input, InputNumber, Row, Select } from 'antd';
+import { Card, Col, Form, Input, Row, Select } from 'antd';
+import InputNumber from '@/components/InputNumber';
 import type { FormInstance } from 'antd/lib/form';
 
 interface BasicInfoProps {

--- a/ui/src/pages/Tenant/New/ResourcePools.tsx
+++ b/ui/src/pages/Tenant/New/ResourcePools.tsx
@@ -1,6 +1,7 @@
 import { SUFFIX_UNIT } from '@/constants';
 import { intl } from '@/utils/intl';
-import { Card, Checkbox, Col, Form, InputNumber, Row } from 'antd';
+import { Card, Checkbox, Col, Form, Row } from 'antd';
+import InputNumber from '@/components/InputNumber';
 import { FormInstance } from 'antd/lib/form';
 import { useEffect, useState } from 'react';
 import styles from './index.less';

--- a/ui/src/pages/Tenant/New/TenantSource.tsx
+++ b/ui/src/pages/Tenant/New/TenantSource.tsx
@@ -11,6 +11,7 @@ import {
   Select,
   Switch,
   TimePicker,
+  Tooltip,
 } from 'antd';
 import { FormInstance } from 'antd/lib/form';
 import { useEffect, useState } from 'react';
@@ -173,99 +174,160 @@ export default function TenantSource({ form, clusterName }: TenantSourceProps) {
                   />
                 </Form.Item>
               </Col>
+              <Form.Item noStyle dependencies={[['source', 'restore', 'type']]}>
+                {({ getFieldValue }) => {
+                  console.log(
+                    'getFieldValue',
+                    getFieldValue(['source', 'restore', 'type']),
+                  );
+
+                  if (getFieldValue(['source', 'restore', 'type']) !== 'NFS') {
+                    return (
+                      <>
+                        <Col span={8}>
+                          <Form.Item
+                            label="OSS AccessID"
+                            name={['source', 'restore', 'ossAccessId']}
+                            rules={[
+                              {
+                                required: true,
+                                message: intl.formatMessage({
+                                  id: 'Dashboard.Tenant.New.TenantSource.EnterOssAccessid',
+                                  defaultMessage: '请输入 OSS AccessID',
+                                }),
+                              },
+                            ]}
+                          >
+                            <Password
+                              placeholder={intl.formatMessage({
+                                id: 'Dashboard.Tenant.New.TenantSource.PleaseEnter',
+                                defaultMessage: '请输入',
+                              })}
+                            />
+                          </Form.Item>
+                        </Col>
+                        <Col span={8}>
+                          <Form.Item
+                            label="OSS AccessKey"
+                            name={['source', 'restore', 'ossAccessKey']}
+                            rules={[
+                              {
+                                required: true,
+                                message: intl.formatMessage({
+                                  id: 'Dashboard.Tenant.New.TenantSource.EnterOssAccesskey',
+                                  defaultMessage: '请输入 OSS AccessKey',
+                                }),
+                              },
+                            ]}
+                          >
+                            <Password
+                              placeholder={intl.formatMessage({
+                                id: 'Dashboard.Tenant.New.TenantSource.PleaseEnter',
+                                defaultMessage: '请输入',
+                              })}
+                            />
+                          </Form.Item>
+                        </Col>
+                      </>
+                    );
+                  } else {
+                    return null;
+                  }
+                }}
+              </Form.Item>
               <Col span={8}>
-                <Form.Item
-                  label="OSS AccessID"
-                  name={['source', 'restore', 'ossAccessId']}
-                  rules={[
-                    {
-                      required: true,
-                      message: intl.formatMessage({
-                        id: 'Dashboard.Tenant.New.TenantSource.EnterOssAccessid',
-                        defaultMessage: '请输入 OSS AccessID',
-                      }),
-                    },
-                  ]}
+                <Tooltip
+                  overlayStyle={{ maxWidth: 300 }}
+                  title={
+                    <div>
+                      <span>
+                        {intl.formatMessage({
+                          id: 'Dashboard.Tenant.New.TenantSource.NfsTypeSeePathFormat',
+                          defaultMessage: 'NFS 类型，参考路径格式：path/to/dir',
+                        })}
+                      </span>
+                      <br />
+                      <span>
+                        {intl.formatMessage({
+                          id: 'Dashboard.Tenant.New.TenantSource.OssTypeForMoreInformation',
+                          defaultMessage:
+                            'OSS 类型，参考路径格式：oss://bucket/dir?host=xxx',
+                        })}
+                      </span>
+                    </div>
+                  }
                 >
-                  <Password
-                    placeholder={intl.formatMessage({
-                      id: 'Dashboard.Tenant.New.TenantSource.PleaseEnter',
-                      defaultMessage: '请输入',
+                  <Form.Item
+                    label={intl.formatMessage({
+                      id: 'Dashboard.Tenant.New.TenantSource.LogArchivePath',
+                      defaultMessage: '日志归档路径',
                     })}
-                  />
-                </Form.Item>
+                    name={['source', 'restore', 'archiveSource']}
+                    rules={[
+                      {
+                        required: true,
+                        message: intl.formatMessage({
+                          id: 'Dashboard.Tenant.New.TenantSource.EnterTheLogArchivePath',
+                          defaultMessage: '请输入日志归档路径',
+                        }),
+                      },
+                    ]}
+                  >
+                    <Input
+                      placeholder={intl.formatMessage({
+                        id: 'Dashboard.Tenant.New.TenantSource.PleaseEnter',
+                        defaultMessage: '请输入',
+                      })}
+                    />
+                  </Form.Item>
+                </Tooltip>
               </Col>
               <Col span={8}>
-                <Form.Item
-                  label="OSS AccessKey"
-                  name={['source', 'restore', 'ossAccessKey']}
-                  rules={[
-                    {
-                      required: true,
-                      message: intl.formatMessage({
-                        id: 'Dashboard.Tenant.New.TenantSource.EnterOssAccesskey',
-                        defaultMessage: '请输入 OSS AccessKey',
-                      }),
-                    },
-                  ]}
+                <Tooltip
+                  overlayStyle={{ maxWidth: 300 }}
+                  title={
+                    <div>
+                      <span>
+                        {intl.formatMessage({
+                          id: 'Dashboard.Tenant.New.TenantSource.NfsTypeSeePathFormat',
+                          defaultMessage: 'NFS 类型，参考路径格式：path/to/dir',
+                        })}
+                      </span>
+                      <br />
+                      <span>
+                        {intl.formatMessage({
+                          id: 'Dashboard.Tenant.New.TenantSource.OssTypeForMoreInformation',
+                          defaultMessage:
+                            'OSS 类型，参考路径格式：oss://bucket/dir?host=xxx',
+                        })}
+                      </span>
+                    </div>
+                  }
                 >
-                  <Password
-                    placeholder={intl.formatMessage({
-                      id: 'Dashboard.Tenant.New.TenantSource.PleaseEnter',
-                      defaultMessage: '请输入',
+                  <Form.Item
+                    label={intl.formatMessage({
+                      id: 'Dashboard.Tenant.New.TenantSource.DataBackupPath',
+                      defaultMessage: '数据备份路径',
                     })}
-                  />
-                </Form.Item>
-              </Col>
-              <Col span={8}>
-                <Form.Item
-                  label={intl.formatMessage({
-                    id: 'Dashboard.Tenant.New.TenantSource.LogArchivePath',
-                    defaultMessage: '日志归档路径',
-                  })}
-                  name={['source', 'restore', 'archiveSource']}
-                  rules={[
-                    {
-                      required: true,
-                      message: intl.formatMessage({
-                        id: 'Dashboard.Tenant.New.TenantSource.EnterTheLogArchivePath',
-                        defaultMessage: '请输入日志归档路径',
-                      }),
-                    },
-                  ]}
-                >
-                  <Input
-                    placeholder={intl.formatMessage({
-                      id: 'Dashboard.Tenant.New.TenantSource.PleaseEnter',
-                      defaultMessage: '请输入',
-                    })}
-                  />
-                </Form.Item>
-              </Col>
-              <Col span={8}>
-                <Form.Item
-                  label={intl.formatMessage({
-                    id: 'Dashboard.Tenant.New.TenantSource.DataBackupPath',
-                    defaultMessage: '数据备份路径',
-                  })}
-                  name={['source', 'restore', 'bakDataSource']}
-                  rules={[
-                    {
-                      required: true,
-                      message: intl.formatMessage({
-                        id: 'Dashboard.Tenant.New.TenantSource.EnterTheDataBackupPath',
-                        defaultMessage: '请输入数据备份路径',
-                      }),
-                    },
-                  ]}
-                >
-                  <Input
-                    placeholder={intl.formatMessage({
-                      id: 'Dashboard.Tenant.New.TenantSource.PleaseEnter',
-                      defaultMessage: '请输入',
-                    })}
-                  />
-                </Form.Item>
+                    name={['source', 'restore', 'bakDataSource']}
+                    rules={[
+                      {
+                        required: true,
+                        message: intl.formatMessage({
+                          id: 'Dashboard.Tenant.New.TenantSource.EnterTheDataBackupPath',
+                          defaultMessage: '请输入数据备份路径',
+                        }),
+                      },
+                    ]}
+                  >
+                    <Input
+                      placeholder={intl.formatMessage({
+                        id: 'Dashboard.Tenant.New.TenantSource.PleaseEnter',
+                        defaultMessage: '请输入',
+                      })}
+                    />
+                  </Form.Item>
+                </Tooltip>
               </Col>
               <Col span={8}>
                 <Form.Item
@@ -355,7 +417,6 @@ export default function TenantSource({ form, clusterName }: TenantSourceProps) {
                   </Col>
                 </Row>
               )}
-              {/* <InputNumber /> */}
             </div>
           </div>
         )}

--- a/ui/src/pages/Tenant/New/index.tsx
+++ b/ui/src/pages/Tenant/New/index.tsx
@@ -68,7 +68,7 @@ export default function New() {
             defaultMessage: '取消',
           })}
         </Button>,
-        <Button key="submit" onClick={() => form.submit()}>
+        <Button type='primary' key="submit" onClick={() => form.submit()}>
           {intl.formatMessage({
             id: 'Dashboard.Tenant.New.Submit',
             defaultMessage: '提交',

--- a/ui/src/pages/Tenant/helper.ts
+++ b/ui/src/pages/Tenant/helper.ts
@@ -87,6 +87,7 @@ export function formatNewTenantForm(
       result[key] = originFormData[key];
     }
   });
+  delete result.source?.restore?.until
   return result;
 }
 /**

--- a/ui/src/pages/Tenant/index.tsx
+++ b/ui/src/pages/Tenant/index.tsx
@@ -2,37 +2,62 @@ import { PageContainer } from '@ant-design/pro-components';
 import { useNavigate } from '@umijs/max';
 import { useRequest } from 'ahooks';
 import { Row } from 'antd';
-import { useState } from 'react';
+import { useEffect,useRef,useState } from 'react';
 
 import EventsTable from '@/components/EventsTable';
 import MonitorComp from '@/components/MonitorComp';
+import { REFRESH_TENANT_TIME } from '@/constants';
 import { getAllTenants } from '@/services/tenant';
 import TenantsList from './TenantsList';
 
 
-import type { LabelType, QueryRangeType } from '../../components/MonitorDetail';
+import type { LabelType,QueryRangeType } from '../../components/MonitorDetail';
 
 const defaultQueryRange: QueryRangeType = {
   step: 20,
   endTimestamp: Math.floor(new Date().valueOf() / 1000),
   startTimestamp: Math.floor(new Date().valueOf() / 1000) - 60 * 30,
 };
-// 租户概览页
+// tenant overview page
 export default function TenantPage() {
   const [filterLabel, setFilterLabel] = useState<LabelType[]>([]);
   const navigate = useNavigate();
-  const { data: tenantsListResponse } = useRequest(getAllTenants, {
-    onSuccess:({data,successful})=>{
-      if(successful){
-        setFilterLabel(data.map((item)=>({
-          key:'tenant_name',
-          value:item.tenantName
-        })));
-      }
-    }
-  });
+  const timerRef = useRef<NodeJS.Timeout>();
+  const { data: tenantsListResponse, refresh: reGetAllTenants } = useRequest(
+    getAllTenants,
+    {
+      onSuccess: ({ data, successful }) => {
+        if (successful) {
+          const operatingTenant = data.find(
+            (tenant) => tenant.status !== 'running',
+          );
+          if (operatingTenant) {
+            timerRef.current = setTimeout(() => {
+              reGetAllTenants();
+            }, REFRESH_TENANT_TIME);
+          } else if (timerRef.current) {
+            clearTimeout(timerRef.current);
+          }
+          setFilterLabel(
+            data.map((item) => ({
+              key: 'tenant_name',
+              value: item.tenantName,
+            })),
+          );
+        }
+      },
+    },
+  );
   const handleAddCluster = () => navigate('new');
   const tenantsList = tenantsListResponse?.data;
+
+  useEffect(()=>{
+    return()=>{
+      if(timerRef.current){
+        clearTimeout(timerRef.current);
+      }
+    }
+  },[])
   
   return (
     <PageContainer>

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -351,9 +351,12 @@ export async function getStorageClasses() {
         toolTipData: toolTipData,
       });
     }
-    return res;
+    return {
+      ...r,
+      data:res
+    };
   }
-  return r.data;
+  return r;
 }
 
 export async function getAllMetrics(type: API.EventObjectType) {

--- a/ui/src/utils/helper.ts
+++ b/ui/src/utils/helper.ts
@@ -1,3 +1,4 @@
+import { intl } from '@/utils/intl';
 type StatisticStatus = 'running' | 'deleting' | 'operating' | 'failed';
 
 type StatisticDataType = { status: StatisticStatus; count: number }[];
@@ -13,19 +14,27 @@ export const formatStatisticData = (
   type: 'cluster' | 'tenant',
   data: StatisticDataType,
 ) => {
-  
-  let r:API.StatisticData = {
+  let r: API.StatisticData = {
     total: 0,
-    name: type === 'cluster' ? 'OceanBase集群' : 'OceanBase租户',
+    name:
+      type === 'cluster'
+        ? intl.formatMessage({
+            id: 'Dashboard.src.utils.helper.OceanbaseCluster',
+            defaultMessage: 'OceanBase集群',
+          })
+        : intl.formatMessage({
+            id: 'Dashboard.src.utils.helper.OceanbaseTenants',
+            defaultMessage: 'OceanBase租户',
+          }),
     type,
     deleting: 0,
     operating: 0,
     running: 0,
-    failed: 0
+    failed: 0,
   };
   for (let item of data) {
     r.total += item.count;
     r[item.status] = item.count;
   }
-  return r
+  return r;
 };


### PR DESCRIPTION
## Summary

1. Add minimum configuration to the observer.
2. If there is only one storage class in the cluster, select it directly without any further pull-down selection.
3. Add `polling` to tenant overview page and tenant details page.
4. Add tooltip to the `Input`.
