### PR TITLE
Feat: add api for getting resource usage of obcluster

### DIFF
--- a/internal/dashboard/business/oceanbase/obcluster.go
+++ b/internal/dashboard/business/oceanbase/obcluster.go
@@ -17,10 +17,9 @@ import (
 	"fmt"
 	"strings"
 
-	logger "github.com/sirupsen/logrus"
-
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	logger "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -432,7 +431,7 @@ func generateOBClusterInstance(param *param.CreateOBClusterParam) *v1alpha1.OBCl
 	case modelcommon.ClusterModeStandalone:
 		obcluster.Labels[oceanbaseconst.AnnotationsMode] = oceanbaseconst.ModeStandalone
 	case modelcommon.ClusterModeService:
-		obcluster.Labels[oceanbaseconst.AnnotationsMode] = "service"
+		obcluster.Labels[oceanbaseconst.AnnotationsMode] = oceanbaseconst.ModeService
 	default:
 	}
 	return obcluster

--- a/internal/dashboard/business/oceanbase/obcluster_usage.go
+++ b/internal/dashboard/business/oceanbase/obcluster_usage.go
@@ -103,16 +103,16 @@ func getServerUsages(gvservers []model.GVOBServer) ([]response.OBServerAvailable
 			zoneMapping[gvserver.Zone] = zoneResource
 		} else {
 			zoneMapping[gvserver.Zone].ServerCount++
-			if zoneMapping[gvserver.Zone].AvailableCPU > serverUsage.AvailableCPU {
+			if zoneMapping[gvserver.Zone].AvailableCPU < serverUsage.AvailableCPU {
 				zoneMapping[gvserver.Zone].AvailableCPU = serverUsage.AvailableCPU
 			}
-			if zoneMapping[gvserver.Zone].AvailableMemory > serverUsage.AvailableMemory {
+			if zoneMapping[gvserver.Zone].AvailableMemory < serverUsage.AvailableMemory {
 				zoneMapping[gvserver.Zone].AvailableMemory = serverUsage.AvailableMemory
 			}
-			if zoneMapping[gvserver.Zone].AvailableLogDisk > serverUsage.AvailableLogDisk {
+			if zoneMapping[gvserver.Zone].AvailableLogDisk < serverUsage.AvailableLogDisk {
 				zoneMapping[gvserver.Zone].AvailableLogDisk = serverUsage.AvailableLogDisk
 			}
-			if zoneMapping[gvserver.Zone].AvailableDataDisk > serverUsage.AvailableDataDisk {
+			if zoneMapping[gvserver.Zone].AvailableDataDisk < serverUsage.AvailableDataDisk {
 				zoneMapping[gvserver.Zone].AvailableDataDisk = serverUsage.AvailableDataDisk
 			}
 		}

--- a/internal/dashboard/business/oceanbase/obcluster_usage.go
+++ b/internal/dashboard/business/oceanbase/obcluster_usage.go
@@ -1,0 +1,112 @@
+/*
+Copyright (c) 2023 OceanBase
+ob-operator is licensed under Mulan PSL v2.
+You can use this software according to the terms and conditions of the Mulan PSL v2.
+You may obtain a copy of Mulan PSL v2 at:
+         http://license.coscl.org.cn/MulanPSL2
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+See the Mulan PSL v2 for more details.
+*/
+
+package oceanbase
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/oceanbase/ob-operator/api/v1alpha1"
+	oceanbaseconst "github.com/oceanbase/ob-operator/internal/const/oceanbase"
+	"github.com/oceanbase/ob-operator/internal/dashboard/model/param"
+	"github.com/oceanbase/ob-operator/internal/dashboard/model/response"
+	"github.com/oceanbase/ob-operator/internal/oceanbase"
+	httpErr "github.com/oceanbase/ob-operator/pkg/errors"
+	"github.com/oceanbase/ob-operator/pkg/k8s/client"
+	"github.com/oceanbase/ob-operator/pkg/oceanbase-sdk/connector"
+	"github.com/oceanbase/ob-operator/pkg/oceanbase-sdk/operation"
+)
+
+func GetOBClusterEssentialParameters(ctx context.Context, nn *param.K8sObjectIdentity) (*response.OBClusterEssentialParameters, error) {
+	obcluster, err := oceanbase.GetOBCluster(ctx, nn.Namespace, nn.Name)
+	if err != nil {
+		return nil, err
+	}
+	clt := client.GetClient()
+	serverList := &v1alpha1.OBServerList{}
+	err = oceanbase.ServerClient.List(ctx, nn.Namespace, serverList, metav1.ListOptions{})
+	if err != nil {
+		return nil, httpErr.NewInternal(err.Error())
+	}
+	rootSecret, err := clt.ClientSet.CoreV1().Secrets(nn.Namespace).Get(ctx, obcluster.Spec.UserSecrets.Root, metav1.GetOptions{})
+	if err != nil {
+		return nil, httpErr.NewInternal(err.Error())
+	}
+	password, ok := rootSecret.Data["password"]
+	if !ok {
+		return nil, httpErr.NewInternal("root password not found")
+	}
+	var manager *operation.OceanbaseOperationManager
+	for _, observer := range serverList.Items {
+		source := connector.NewOceanBaseDataSource(observer.Status.GetConnectAddr(), oceanbaseconst.SqlPort, "root", "sys", string(password), oceanbaseconst.DefaultDatabase)
+		manager, err = operation.GetOceanbaseOperationManager(source)
+		if err == nil {
+			break
+		}
+	}
+	if manager == nil {
+		return nil, httpErr.NewInternal("no running observer is connectable")
+	}
+	defer manager.Close()
+
+	parameters, err := manager.GetParameter("__min_full_resource_pool_memory", nil)
+	if err != nil {
+		return nil, httpErr.NewInternal(err.Error())
+	}
+	minPoolMemory, err := resource.ParseQuantity(parameters[0].Value)
+	if err != nil {
+		return nil, httpErr.NewInternal(err.Error())
+	}
+	essentials := &response.OBClusterEssentialParameters{
+		MinPoolMemory: minPoolMemory.Value(),
+	}
+	zoneMapping := make(map[string]response.OBZoneAvaiableResource)
+	gvservers, err := manager.ListGVServers()
+	if err != nil {
+		return nil, httpErr.NewInternal(err.Error())
+	}
+	serverUsages := make([]*response.OBServerAvailableResource, 0, len(gvservers))
+	for _, gvserver := range gvservers {
+		if _, ok := zoneMapping[gvserver.Zone]; !ok {
+			zoneMapping[gvserver.Zone] = response.OBZoneAvaiableResource{
+				OBZone:            gvserver.Zone,
+				AvailableCPU:      gvserver.CPUCapacity - gvserver.CPUAssigned,
+				AvailableMemory:   gvserver.MemCapacity - gvserver.MemAssigned,
+				AvailableLogDisk:  gvserver.LogDiskCapacity - gvserver.LogDiskAssigned,
+				AvailableDataDisk: gvserver.DataDiskCapacity - gvserver.DataDiskAllocated,
+			}
+		}
+		serverUsage := &response.OBServerAvailableResource{
+			OBServerIP: gvserver.ServerIP,
+			OBZoneAvaiableResource: response.OBZoneAvaiableResource{
+				OBZone:            gvserver.Zone,
+				AvailableCPU:      gvserver.CPUCapacity - gvserver.CPUAssigned,
+				AvailableMemory:   gvserver.MemCapacity - gvserver.MemAssigned,
+				AvailableLogDisk:  gvserver.LogDiskCapacity - gvserver.LogDiskAssigned,
+				AvailableDataDisk: gvserver.DataDiskCapacity - gvserver.DataDiskAllocated,
+			},
+		}
+		if zoneMapping[gvserver.Zone].AvailableCPU > serverUsage.AvailableCPU ||
+			zoneMapping[gvserver.Zone].AvailableMemory > serverUsage.AvailableMemory ||
+			zoneMapping[gvserver.Zone].AvailableLogDisk > serverUsage.AvailableLogDisk ||
+			zoneMapping[gvserver.Zone].AvailableDataDisk > serverUsage.AvailableDataDisk {
+			zoneMapping[gvserver.Zone] = serverUsage.OBZoneAvaiableResource
+		}
+		serverUsages = append(serverUsages, serverUsage)
+	}
+	essentials.OBServerResources = serverUsages
+	essentials.OBZoneResourceMap = zoneMapping
+	return essentials, nil
+}

--- a/internal/dashboard/business/oceanbase/obcluster_usage_test.go
+++ b/internal/dashboard/business/oceanbase/obcluster_usage_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright (c) 2023 OceanBase
+ob-operator is licensed under Mulan PSL v2.
+You can use this software according to the terms and conditions of the Mulan PSL v2.
+You may obtain a copy of Mulan PSL v2 at:
+         http://license.coscl.org.cn/MulanPSL2
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+See the Mulan PSL v2 for more details.
+*/
+
+package oceanbase
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/oceanbase/ob-operator/pkg/oceanbase-sdk/model"
+)
+
+func getMockedGVOBServers() []model.GVOBServer {
+	return []model.GVOBServer{{
+		ServerIP:          "1",
+		Zone:              "zone1",
+		CPUCapacity:       16,
+		CPUAssigned:       3,
+		MemCapacity:       16,
+		MemAssigned:       3,
+		MemoryLimit:       32,
+		LogDiskCapacity:   100,
+		LogDiskAssigned:   40,
+		DataDiskCapacity:  100,
+		DataDiskAllocated: 60,
+	}, {
+		ServerIP:          "2",
+		Zone:              "zone1",
+		CPUCapacity:       16,
+		CPUAssigned:       10, // max in zone1
+		MemCapacity:       16,
+		MemAssigned:       3,
+		MemoryLimit:       32,
+		LogDiskCapacity:   100,
+		LogDiskAssigned:   40,
+		DataDiskCapacity:  100,
+		DataDiskAllocated: 60,
+	}, {
+		ServerIP:          "3",
+		Zone:              "zone1",
+		CPUCapacity:       16,
+		CPUAssigned:       3,
+		MemCapacity:       16,
+		MemAssigned:       12, // max in zone1
+		MemoryLimit:       32,
+		LogDiskCapacity:   100,
+		LogDiskAssigned:   40,
+		DataDiskCapacity:  100,
+		DataDiskAllocated: 60,
+	}, {
+		ServerIP:          "4",
+		Zone:              "zone2",
+		CPUCapacity:       16,
+		CPUAssigned:       3,
+		MemCapacity:       16,
+		MemAssigned:       5,
+		MemoryLimit:       32,
+		LogDiskCapacity:   100,
+		LogDiskAssigned:   40,
+		DataDiskCapacity:  100,
+		DataDiskAllocated: 60,
+	}}
+}
+
+var _ = Describe("Test OBClsuter usage", func() {
+	It("Get observer usages", func() {
+		servers, zoneMapping := getServerUsages(getMockedGVOBServers())
+		Expect(servers).To(HaveLen(4))
+		Expect(servers[0].AvailableCPU).To(Equal(int64(13)))
+		Expect(servers[0].AvailableMemory).To(Equal(int64(13)))
+		Expect(servers[1].AvailableCPU).To(Equal(int64(6)))
+		Expect(servers[1].AvailableMemory).To(Equal(int64(13)))
+		Expect(servers[2].AvailableCPU).To(Equal(int64(13)))
+		Expect(servers[2].AvailableMemory).To(Equal(int64(4)))
+
+		Expect(zoneMapping).To(HaveLen(2))
+		Expect(zoneMapping).To(HaveKey("zone1"))
+		Expect(zoneMapping).To(HaveKey("zone2"))
+		Expect(zoneMapping["zone1"].AvailableCPU).To(Equal(int64(6)))
+		Expect(zoneMapping["zone1"].AvailableMemory).To(Equal(int64(4)))
+		Expect(zoneMapping["zone1"].AvailableDataDisk).To(Equal(int64(40)))
+		Expect(zoneMapping["zone1"].AvailableLogDisk).To(Equal(int64(60)))
+		Expect(zoneMapping["zone2"].AvailableCPU).To(Equal(int64(13)))
+		Expect(zoneMapping["zone2"].AvailableMemory).To(Equal(int64(11)))
+		Expect(zoneMapping["zone2"].AvailableDataDisk).To(Equal(int64(40)))
+		Expect(zoneMapping["zone2"].AvailableLogDisk).To(Equal(int64(60)))
+	})
+})

--- a/internal/dashboard/generated/swagger/docs.go
+++ b/internal/dashboard/generated/swagger/docs.go
@@ -1236,6 +1236,81 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/obclusters/{namespace}/{name}/essential-parameters": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "list essential parameters of specific obcluster",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Obcluster"
+                ],
+                "summary": "list essential parameters",
+                "operationId": "ListEssentialParameters",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "obcluster namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "obcluster name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/response.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/response.OBClusterEssentialParameters"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/response.APIResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/response.APIResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.APIResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/obtenants": {
             "get": {
                 "security": [
@@ -3437,6 +3512,27 @@ const docTemplate = `{
                 }
             }
         },
+        "response.OBClusterEssentialParameters": {
+            "type": "object",
+            "properties": {
+                "minPoolMemory": {
+                    "type": "integer",
+                    "example": 2147483648
+                },
+                "obServerResources": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/response.OBServerAvailableResource"
+                    }
+                },
+                "obZoneResourceMap": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/response.OBZoneAvaiableResource"
+                    }
+                }
+            }
+        },
         "response.OBClusterStastistic": {
             "type": "object",
             "properties": {
@@ -3482,6 +3578,34 @@ const docTemplate = `{
                 },
                 "statusDetail": {
                     "type": "string"
+                }
+            }
+        },
+        "response.OBServerAvailableResource": {
+            "type": "object",
+            "properties": {
+                "availableCPU": {
+                    "type": "integer",
+                    "example": 12
+                },
+                "availableDataDisk": {
+                    "type": "integer",
+                    "example": 16106127360
+                },
+                "availableLogDisk": {
+                    "type": "integer",
+                    "example": 5368709120
+                },
+                "availableMemory": {
+                    "type": "integer",
+                    "example": 5368709120
+                },
+                "obServerIP": {
+                    "type": "string"
+                },
+                "obZone": {
+                    "type": "string",
+                    "example": "zone1"
                 }
             }
         },
@@ -3699,6 +3823,31 @@ const docTemplate = `{
                 },
                 "zone": {
                     "type": "string"
+                }
+            }
+        },
+        "response.OBZoneAvaiableResource": {
+            "type": "object",
+            "properties": {
+                "availableCPU": {
+                    "type": "integer",
+                    "example": 12
+                },
+                "availableDataDisk": {
+                    "type": "integer",
+                    "example": 16106127360
+                },
+                "availableLogDisk": {
+                    "type": "integer",
+                    "example": 5368709120
+                },
+                "availableMemory": {
+                    "type": "integer",
+                    "example": 5368709120
+                },
+                "obZone": {
+                    "type": "string",
+                    "example": "zone1"
                 }
             }
         },

--- a/internal/dashboard/generated/swagger/docs.go
+++ b/internal/dashboard/generated/swagger/docs.go
@@ -1254,7 +1254,7 @@ const docTemplate = `{
                     "Obcluster"
                 ],
                 "summary": "list essential parameters",
-                "operationId": "ListEssentialParameters",
+                "operationId": "ListOBClusterResources",
                 "parameters": [
                     {
                         "type": "string",
@@ -1283,7 +1283,7 @@ const docTemplate = `{
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/response.OBClusterEssentialParameters"
+                                            "$ref": "#/definitions/response.OBClusterResources"
                                         }
                                     }
                                 }
@@ -3512,7 +3512,7 @@ const docTemplate = `{
                 }
             }
         },
-        "response.OBClusterEssentialParameters": {
+        "response.OBClusterResources": {
             "type": "object",
             "properties": {
                 "minPoolMemory": {
@@ -3606,6 +3606,10 @@ const docTemplate = `{
                 "obZone": {
                     "type": "string",
                     "example": "zone1"
+                },
+                "serverCount": {
+                    "type": "integer",
+                    "example": 3
                 }
             }
         },
@@ -3848,6 +3852,10 @@ const docTemplate = `{
                 "obZone": {
                     "type": "string",
                     "example": "zone1"
+                },
+                "serverCount": {
+                    "type": "integer",
+                    "example": 3
                 }
             }
         },

--- a/internal/dashboard/generated/swagger/swagger.json
+++ b/internal/dashboard/generated/swagger/swagger.json
@@ -1229,6 +1229,81 @@
                 }
             }
         },
+        "/api/v1/obclusters/{namespace}/{name}/essential-parameters": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "list essential parameters of specific obcluster",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Obcluster"
+                ],
+                "summary": "list essential parameters",
+                "operationId": "ListEssentialParameters",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "obcluster namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "obcluster name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/response.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/response.OBClusterEssentialParameters"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/response.APIResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/response.APIResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.APIResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/obtenants": {
             "get": {
                 "security": [
@@ -3430,6 +3505,27 @@
                 }
             }
         },
+        "response.OBClusterEssentialParameters": {
+            "type": "object",
+            "properties": {
+                "minPoolMemory": {
+                    "type": "integer",
+                    "example": 2147483648
+                },
+                "obServerResources": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/response.OBServerAvailableResource"
+                    }
+                },
+                "obZoneResourceMap": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/response.OBZoneAvaiableResource"
+                    }
+                }
+            }
+        },
         "response.OBClusterStastistic": {
             "type": "object",
             "properties": {
@@ -3475,6 +3571,34 @@
                 },
                 "statusDetail": {
                     "type": "string"
+                }
+            }
+        },
+        "response.OBServerAvailableResource": {
+            "type": "object",
+            "properties": {
+                "availableCPU": {
+                    "type": "integer",
+                    "example": 12
+                },
+                "availableDataDisk": {
+                    "type": "integer",
+                    "example": 16106127360
+                },
+                "availableLogDisk": {
+                    "type": "integer",
+                    "example": 5368709120
+                },
+                "availableMemory": {
+                    "type": "integer",
+                    "example": 5368709120
+                },
+                "obServerIP": {
+                    "type": "string"
+                },
+                "obZone": {
+                    "type": "string",
+                    "example": "zone1"
                 }
             }
         },
@@ -3692,6 +3816,31 @@
                 },
                 "zone": {
                     "type": "string"
+                }
+            }
+        },
+        "response.OBZoneAvaiableResource": {
+            "type": "object",
+            "properties": {
+                "availableCPU": {
+                    "type": "integer",
+                    "example": 12
+                },
+                "availableDataDisk": {
+                    "type": "integer",
+                    "example": 16106127360
+                },
+                "availableLogDisk": {
+                    "type": "integer",
+                    "example": 5368709120
+                },
+                "availableMemory": {
+                    "type": "integer",
+                    "example": 5368709120
+                },
+                "obZone": {
+                    "type": "string",
+                    "example": "zone1"
                 }
             }
         },

--- a/internal/dashboard/generated/swagger/swagger.json
+++ b/internal/dashboard/generated/swagger/swagger.json
@@ -1247,7 +1247,7 @@
                     "Obcluster"
                 ],
                 "summary": "list essential parameters",
-                "operationId": "ListEssentialParameters",
+                "operationId": "ListOBClusterResources",
                 "parameters": [
                     {
                         "type": "string",
@@ -1276,7 +1276,7 @@
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/response.OBClusterEssentialParameters"
+                                            "$ref": "#/definitions/response.OBClusterResources"
                                         }
                                     }
                                 }
@@ -3505,7 +3505,7 @@
                 }
             }
         },
-        "response.OBClusterEssentialParameters": {
+        "response.OBClusterResources": {
             "type": "object",
             "properties": {
                 "minPoolMemory": {
@@ -3599,6 +3599,10 @@
                 "obZone": {
                     "type": "string",
                     "example": "zone1"
+                },
+                "serverCount": {
+                    "type": "integer",
+                    "example": 3
                 }
             }
         },
@@ -3841,6 +3845,10 @@
                 "obZone": {
                     "type": "string",
                     "example": "zone1"
+                },
+                "serverCount": {
+                    "type": "integer",
+                    "example": 3
                 }
             }
         },

--- a/internal/dashboard/generated/swagger/swagger.yaml
+++ b/internal/dashboard/generated/swagger/swagger.yaml
@@ -718,7 +718,7 @@ definitions:
       version:
         type: string
     type: object
-  response.OBClusterEssentialParameters:
+  response.OBClusterResources:
     properties:
       minPoolMemory:
         example: 2147483648
@@ -782,6 +782,9 @@ definitions:
       obZone:
         example: zone1
         type: string
+      serverCount:
+        example: 3
+        type: integer
     type: object
   response.OBTenantBrief:
     description: Brief information about OBTenant
@@ -951,6 +954,9 @@ definitions:
       obZone:
         example: zone1
         type: string
+      serverCount:
+        example: 3
+        type: integer
     type: object
   response.RestoreSource:
     properties:
@@ -1455,7 +1461,7 @@ paths:
       consumes:
       - application/json
       description: list essential parameters of specific obcluster
-      operationId: ListEssentialParameters
+      operationId: ListOBClusterResources
       parameters:
       - description: obcluster namespace
         in: path
@@ -1477,7 +1483,7 @@ paths:
             - $ref: '#/definitions/response.APIResponse'
             - properties:
                 data:
-                  $ref: '#/definitions/response.OBClusterEssentialParameters'
+                  $ref: '#/definitions/response.OBClusterResources'
               type: object
         "400":
           description: Bad Request

--- a/internal/dashboard/generated/swagger/swagger.yaml
+++ b/internal/dashboard/generated/swagger/swagger.yaml
@@ -718,6 +718,20 @@ definitions:
       version:
         type: string
     type: object
+  response.OBClusterEssentialParameters:
+    properties:
+      minPoolMemory:
+        example: 2147483648
+        type: integer
+      obServerResources:
+        items:
+          $ref: '#/definitions/response.OBServerAvailableResource'
+        type: array
+      obZoneResourceMap:
+        additionalProperties:
+          $ref: '#/definitions/response.OBZoneAvaiableResource'
+        type: object
+    type: object
   response.OBClusterStastistic:
     properties:
       count:
@@ -747,6 +761,26 @@ definitions:
       status:
         type: string
       statusDetail:
+        type: string
+    type: object
+  response.OBServerAvailableResource:
+    properties:
+      availableCPU:
+        example: 12
+        type: integer
+      availableDataDisk:
+        example: 16106127360
+        type: integer
+      availableLogDisk:
+        example: 5368709120
+        type: integer
+      availableMemory:
+        example: 5368709120
+        type: integer
+      obServerIP:
+        type: string
+      obZone:
+        example: zone1
         type: string
     type: object
   response.OBTenantBrief:
@@ -898,6 +932,24 @@ definitions:
           $ref: '#/definitions/common.KVPair'
         type: array
       zone:
+        type: string
+    type: object
+  response.OBZoneAvaiableResource:
+    properties:
+      availableCPU:
+        example: 12
+        type: integer
+      availableDataDisk:
+        example: 16106127360
+        type: integer
+      availableLogDisk:
+        example: 5368709120
+        type: integer
+      availableMemory:
+        example: 5368709120
+        type: integer
+      obZone:
+        example: zone1
         type: string
     type: object
   response.RestoreSource:
@@ -1396,6 +1448,52 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: create obcluster
+      tags:
+      - Obcluster
+  /api/v1/obclusters/{namespace}/{name}/essential-parameters:
+    get:
+      consumes:
+      - application/json
+      description: list essential parameters of specific obcluster
+      operationId: ListEssentialParameters
+      parameters:
+      - description: obcluster namespace
+        in: path
+        name: namespace
+        required: true
+        type: string
+      - description: obcluster name
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/response.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/response.OBClusterEssentialParameters'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/response.APIResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/response.APIResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/response.APIResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: list essential parameters
       tags:
       - Obcluster
   /api/v1/obclusters/namespace/{namespace}/name/{name}:

--- a/internal/dashboard/handler/obcluster_handler.go
+++ b/internal/dashboard/handler/obcluster_handler.go
@@ -276,7 +276,7 @@ func DeleteOBZone(c *gin.Context) (any, error) {
 	return nil, nil
 }
 
-// @ID ListEssentialParameters
+// @ID ListOBClusterResources
 // @Summary list essential parameters
 // @Description list essential parameters of specific obcluster
 // @Tags Obcluster
@@ -284,13 +284,13 @@ func DeleteOBZone(c *gin.Context) (any, error) {
 // @Produce application/json
 // @Param namespace path string true "obcluster namespace"
 // @Param name path string true "obcluster name"
-// @Success 200 object response.APIResponse{data=response.OBClusterEssentialParameters}
+// @Success 200 object response.APIResponse{data=response.OBClusterResources}
 // @Failure 400 object response.APIResponse
 // @Failure 401 object response.APIResponse
 // @Failure 500 object response.APIResponse
 // @Router /api/v1/obclusters/{namespace}/{name}/essential-parameters [GET]
 // @Security ApiKeyAuth
-func ListEssentialParameters(c *gin.Context) (*response.OBClusterEssentialParameters, error) {
+func ListOBClusterResources(c *gin.Context) (*response.OBClusterResources, error) {
 	obclusterIdentity := &param.K8sObjectIdentity{}
 	err := c.BindUri(obclusterIdentity)
 	if err != nil {

--- a/internal/dashboard/handler/obcluster_handler.go
+++ b/internal/dashboard/handler/obcluster_handler.go
@@ -275,3 +275,26 @@ func DeleteOBZone(c *gin.Context) (any, error) {
 	}
 	return nil, nil
 }
+
+// @ID ListEssentialParameters
+// @Summary list essential parameters
+// @Description list essential parameters of specific obcluster
+// @Tags Obcluster
+// @Accept application/json
+// @Produce application/json
+// @Param namespace path string true "obcluster namespace"
+// @Param name path string true "obcluster name"
+// @Success 200 object response.APIResponse{data=response.OBClusterEssentialParameters}
+// @Failure 400 object response.APIResponse
+// @Failure 401 object response.APIResponse
+// @Failure 500 object response.APIResponse
+// @Router /api/v1/obclusters/{namespace}/{name}/essential-parameters [GET]
+// @Security ApiKeyAuth
+func ListEssentialParameters(c *gin.Context) (*response.OBClusterEssentialParameters, error) {
+	obclusterIdentity := &param.K8sObjectIdentity{}
+	err := c.BindUri(obclusterIdentity)
+	if err != nil {
+		return nil, httpErr.NewBadRequest(err.Error())
+	}
+	return oceanbase.GetOBClusterEssentialParameters(c, obclusterIdentity)
+}

--- a/internal/dashboard/model/response/obcluster.go
+++ b/internal/dashboard/model/response/obcluster.go
@@ -85,7 +85,7 @@ type NFSVolumeSpec struct {
 	Path    string `json:"path"`
 }
 
-type OBClusterEssentialParameters struct {
+type OBClusterResources struct {
 	MinPoolMemory     int64                              `json:"minPoolMemory" example:"2147483648"`
 	OBServerResources []OBServerAvailableResource        `json:"obServerResources"`
 	OBZoneResourceMap map[string]*OBZoneAvaiableResource `json:"obZoneResourceMap"`
@@ -97,6 +97,7 @@ type OBServerAvailableResource struct {
 }
 
 type OBZoneAvaiableResource struct {
+	ServerCount       int64  `json:"serverCount" example:"3"`
 	OBZone            string `json:"obZone" example:"zone1"`
 	AvailableLogDisk  int64  `json:"availableLogDisk" example:"5368709120"`
 	AvailableDataDisk int64  `json:"availableDataDisk" example:"16106127360"`

--- a/internal/dashboard/model/response/obcluster.go
+++ b/internal/dashboard/model/response/obcluster.go
@@ -86,9 +86,9 @@ type NFSVolumeSpec struct {
 }
 
 type OBClusterEssentialParameters struct {
-	MinPoolMemory     int64                             `json:"minPoolMemory" example:"2147483648"`
-	OBServerResources []*OBServerAvailableResource      `json:"obServerResources"`
-	OBZoneResourceMap map[string]OBZoneAvaiableResource `json:"obZoneResourceMap"`
+	MinPoolMemory     int64                              `json:"minPoolMemory" example:"2147483648"`
+	OBServerResources []OBServerAvailableResource        `json:"obServerResources"`
+	OBZoneResourceMap map[string]*OBZoneAvaiableResource `json:"obZoneResourceMap"`
 }
 
 type OBServerAvailableResource struct {

--- a/internal/dashboard/model/response/obcluster.go
+++ b/internal/dashboard/model/response/obcluster.go
@@ -84,3 +84,22 @@ type NFSVolumeSpec struct {
 	Address string `json:"address"`
 	Path    string `json:"path"`
 }
+
+type OBClusterEssentialParameters struct {
+	MinPoolMemory     int64                             `json:"minPoolMemory" example:"2147483648"`
+	OBServerResources []*OBServerAvailableResource      `json:"obServerResources"`
+	OBZoneResourceMap map[string]OBZoneAvaiableResource `json:"obZoneResourceMap"`
+}
+
+type OBServerAvailableResource struct {
+	OBServerIP             string `json:"obServerIP"`
+	OBZoneAvaiableResource `json:",inline"`
+}
+
+type OBZoneAvaiableResource struct {
+	OBZone            string `json:"obZone" example:"zone1"`
+	AvailableLogDisk  int64  `json:"availableLogDisk" example:"5368709120"`
+	AvailableDataDisk int64  `json:"availableDataDisk" example:"16106127360"`
+	AvailableMemory   int64  `json:"availableMemory" example:"5368709120"`
+	AvailableCPU      int64  `json:"availableCPU" example:"12"`
+}

--- a/internal/dashboard/router/router.go
+++ b/internal/dashboard/router/router.go
@@ -60,6 +60,7 @@ func InitRoutes(router *gin.Engine) {
 	if os.Getenv("ENABLE_SWAGGER_DOC") == "true" {
 		docs.SwaggerInfo.BasePath = "/"
 		router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))
+		router.Use(static.Serve("/api-gen", static.LocalFile("internal/dashboard/generated/swagger", false)))
 	}
 
 	// login api does not require login

--- a/internal/dashboard/router/v1/obcluster_router.go
+++ b/internal/dashboard/router/v1/obcluster_router.go
@@ -28,5 +28,5 @@ func InitOBClusterRoutes(g *gin.RouterGroup) {
 	g.POST("/obclusters/namespace/:namespace/name/:name/obzones", h.Wrap(h.AddOBZone))
 	g.POST("/obclusters/namespace/:namespace/name/:name/obzones/:obzoneName/scale", h.Wrap(h.ScaleOBServer))
 	g.DELETE("/obclusters/namespace/:namespace/name/:name/obzones/:obzoneName", h.Wrap(h.DeleteOBZone))
-	g.GET("/obclusters/:namespace/:name/essential-parameters", h.Wrap(h.ListEssentialParameters))
+	g.GET("/obclusters/:namespace/:name/essential-parameters", h.Wrap(h.ListOBClusterResources))
 }

--- a/internal/dashboard/router/v1/obcluster_router.go
+++ b/internal/dashboard/router/v1/obcluster_router.go
@@ -28,4 +28,5 @@ func InitOBClusterRoutes(g *gin.RouterGroup) {
 	g.POST("/obclusters/namespace/:namespace/name/:name/obzones", h.Wrap(h.AddOBZone))
 	g.POST("/obclusters/namespace/:namespace/name/:name/obzones/:obzoneName/scale", h.Wrap(h.ScaleOBServer))
 	g.DELETE("/obclusters/namespace/:namespace/name/:name/obzones/:obzoneName", h.Wrap(h.DeleteOBZone))
+	g.GET("/obclusters/:namespace/:name/essential-parameters", h.Wrap(h.ListEssentialParameters))
 }

--- a/pkg/oceanbase-sdk/const/sql/server.go
+++ b/pkg/oceanbase-sdk/const/sql/server.go
@@ -18,3 +18,7 @@ const (
 	AddServer    = "alter system add server ?"
 	DeleteServer = "alter system delete server ?"
 )
+
+const (
+	ListGVServers = "select svr_ip, svr_port, zone, sql_port, cpu_capacity, cpu_capacity_max, cpu_assigned, cpu_assigned_max, mem_capacity, mem_assigned, memory_limit, log_disk_capacity, log_disk_assigned, data_disk_capacity, data_disk_allocated, data_disk_in_use, data_disk_health_status from oceanbase.GV$OB_SERVERS"
+)

--- a/pkg/oceanbase-sdk/model/server.go
+++ b/pkg/oceanbase-sdk/model/server.go
@@ -31,3 +31,24 @@ type OBServer struct {
 	StartServiceTime int64  `json:"start_service_time" db:"start_service_time"`
 	BuildVersion     string `json:"build_version" db:"build_version"`
 }
+
+// GVOBServer shows the usage info of the server
+type GVOBServer struct {
+	ServerIP             string `json:"svrIp" db:"svr_ip"`
+	Port                 int64  `json:"svrPort" db:"svr_port"`
+	Zone                 string `json:"zone" db:"zone"`
+	SQLPort              int64  `json:"sqlPort" db:"sql_port"`
+	CPUCapacity          int64  `json:"cpuCapacity" db:"cpu_capacity"`
+	CPUCapacityMax       int64  `json:"cpuCapacityMax" db:"cpu_capacity_max"`
+	CPUAssigned          int64  `json:"cpuAssigned" db:"cpu_assigned"`
+	CPUAssignedMax       int64  `json:"cpuAssignedMax" db:"cpu_assigned_max"`
+	MemCapacity          int64  `json:"memCapacity" db:"mem_capacity"`
+	MemAssigned          int64  `json:"memAssigned" db:"mem_assigned"`
+	MemoryLimit          int64  `json:"memoryLimit" db:"memory_limit"`
+	LogDiskCapacity      int64  `json:"logDiskCapacity" db:"log_disk_capacity"`
+	LogDiskAssigned      int64  `json:"logDiskAssigned" db:"log_disk_assigned"`
+	DataDiskCapacity     int64  `json:"dataDiskCapacity" db:"data_disk_capacity"`
+	DataDiskAllocated    int64  `json:"dataDiskAllocated" db:"data_disk_allocated"`
+	DataDiskInUse        int64  `json:"dataDiskInUse" db:"data_disk_in_use"`
+	DataDiskHealthStatus string `json:"dataDiskHealthStatus" db:"data_disk_health_status"`
+}

--- a/pkg/oceanbase-sdk/operation/server.go
+++ b/pkg/oceanbase-sdk/operation/server.go
@@ -61,3 +61,12 @@ func (m *OceanbaseOperationManager) DeleteServer(serverInfo *model.ServerInfo) e
 	}
 	return nil
 }
+
+func (m *OceanbaseOperationManager) ListGVServers() ([]model.GVOBServer, error) {
+	observers := make([]model.GVOBServer, 0)
+	err := m.QueryList(&observers, sql.ListGVServers)
+	if err != nil {
+		return nil, errors.Wrap(err, "List observer failed")
+	}
+	return observers, nil
+}


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

In order to restrict the resource quantity that use may specify when creating tenant, it's necessary to fetch how much available resource is there in the cluster.

1. Added an api to fetch available resource in specific cluster
2. Added unit test for it
