### PR TITLE
Fix: Remove early return in status _failed_

### DIFF
--- a/internal/resource/obcluster/obcluster_manager.go
+++ b/internal/resource/obcluster/obcluster_manager.go
@@ -143,9 +143,6 @@ func (m *OBClusterManager) retryUpdateStatus() error {
 }
 
 func (m *OBClusterManager) UpdateStatus() error {
-	if m.OBCluster.Status.Status == "Failed" {
-		return nil
-	}
 	// update obzone status
 	obzoneList, err := m.listOBZones()
 	if err != nil {

--- a/internal/resource/obparameter/obparameter_manager.go
+++ b/internal/resource/obparameter/obparameter_manager.go
@@ -127,9 +127,6 @@ func (m *OBParameterManager) retryUpdateStatus() error {
 }
 
 func (m *OBParameterManager) UpdateStatus() error {
-	if m.OBParameter.Status.Status == "Failed" {
-		return nil
-	}
 	obcluster, err := m.getOBCluster()
 	if err != nil {
 		return errors.Wrap(err, "Get obcluster from K8s")

--- a/internal/resource/observer/observer_manager.go
+++ b/internal/resource/observer/observer_manager.go
@@ -165,8 +165,6 @@ func (m *OBServerManager) UpdateStatus() error {
 	// update deleting status when object is deleting
 	if m.IsDeleting() {
 		m.OBServer.Status.Status = serverstatus.Deleting
-	} else if m.OBServer.Status.Status == "Failed" {
-		return nil
 	} else {
 		pod, err := m.getPod()
 		if err != nil {

--- a/internal/resource/obtenant/obtenant_manager.go
+++ b/internal/resource/obtenant/obtenant_manager.go
@@ -171,8 +171,6 @@ func (m *OBTenantManager) UpdateStatus() error {
 		m.OBTenant.Status.Status = tenantstatus.CancelingRestore
 	} else if m.OBTenant.Status.Status != tenantstatus.Running {
 		m.Logger.V(oceanbaseconst.LogLevelTrace).Info(fmt.Sprintf("OBTenant status is %s (not running), skip compare", m.OBTenant.Status.Status))
-	} else if m.OBTenant.Status.Status == "Failed" {
-		return nil
 	} else {
 		// build tenant status from DB
 		tenantStatusCurrent, err := m.buildTenantStatus()

--- a/internal/resource/obtenantbackuppolicy/obtenantbackuppolicy_manager.go
+++ b/internal/resource/obtenantbackuppolicy/obtenantbackuppolicy_manager.go
@@ -160,9 +160,6 @@ func (m *ObTenantBackupPolicyManager) FinishTask() {
 }
 
 func (m *ObTenantBackupPolicyManager) UpdateStatus() error {
-	if m.BackupPolicy.Status.Status == apitypes.BackupPolicyStatusType("Failed") {
-		return nil
-	}
 	if m.BackupPolicy.Spec.Suspend && m.BackupPolicy.Status.Status == constants.BackupPolicyStatusRunning {
 		m.BackupPolicy.Status.Status = constants.BackupPolicyStatusPausing
 		m.BackupPolicy.Status.OperationContext = nil

--- a/internal/resource/obtenantrestore/obtenantrestore_manager.go
+++ b/internal/resource/obtenantrestore/obtenantrestore_manager.go
@@ -169,8 +169,6 @@ func (m ObTenantRestoreManager) UpdateStatus() error {
 		if err != nil {
 			return err
 		}
-	} else if m.Resource.Status.Status == apitypes.RestoreJobStatus("Failed") {
-		return nil
 	}
 	return m.retryUpdateStatus()
 }

--- a/internal/resource/obzone/obzone_manager.go
+++ b/internal/resource/obzone/obzone_manager.go
@@ -190,9 +190,6 @@ func (m *OBZoneManager) retryUpdateStatus() error {
 }
 
 func (m *OBZoneManager) UpdateStatus() error {
-	if m.OBZone.Status.Status == "Failed" {
-		return nil
-	}
 	observerList, err := m.listOBServers()
 	if err != nil {
 		m.Logger.Error(err, "Got error when list observers")


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

Removed early return when the resource is in status `failed`, avoiding infinite retry.
