### PR TITLE
fix(backup): remove restriction for deleting wrong backup policy

### DIFF
--- a/internal/resource/obtenantbackuppolicy/obtenantbackuppolicy_flow.go
+++ b/internal/resource/obtenantbackuppolicy/obtenantbackuppolicy_flow.go
@@ -23,6 +23,9 @@ func PrepareBackupPolicy() *tasktypes.TaskFlow {
 			Name:         fPrepareBackupPolicy,
 			Tasks:        []tasktypes.TaskName{tConfigureServerForBackup},
 			TargetStatus: string(constants.BackupPolicyStatusPrepared),
+			OnFailure: tasktypes.FailureRule{
+				NextTryStatus: string(constants.BackupPolicyStatusFailed),
+			},
 		},
 	}
 }
@@ -33,6 +36,9 @@ func StartBackupJob() *tasktypes.TaskFlow {
 			Name:         fStartBackupJob,
 			Tasks:        []tasktypes.TaskName{tStartBackupJob},
 			TargetStatus: string(constants.BackupPolicyStatusRunning),
+			OnFailure: tasktypes.FailureRule{
+				NextTryStatus: string(constants.BackupPolicyStatusFailed),
+			},
 		},
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->


Remove restriction for deleting wrong backup policy. If the backup policy has not been initialized, delete it directly without cleaning.
