### PR TITLE
fix:Field clusterResourceName instead of clusterName

### DIFF
--- a/ui/src/components/customModal/ModifyUnitDetailModal.tsx
+++ b/ui/src/components/customModal/ModifyUnitDetailModal.tsx
@@ -29,7 +29,7 @@ export type UnitDetailType = {
 
 type UnitConfigType = {
   clusterList?: API.SimpleClusterList;
-  clusterName?: string;
+  clusterResourceName?: string;
   essentialParameter?: API.EssentialParametersType;
   setClusterList: React.Dispatch<React.SetStateAction<API.SimpleClusterList>>;
 };
@@ -41,7 +41,7 @@ export default function ModifyUnitDetailModal({
   clusterList = [],
   setClusterList,
   essentialParameter = {},
-  clusterName = '',
+  clusterResourceName = '',
 }: CommonModalType & UnitConfigType) {
   const [form] = Form.useForm<UnitDetailType>();
   const [minMemory, setMinMemory] = useState<number>(2);
@@ -76,14 +76,14 @@ export default function ModifyUnitDetailModal({
       setSelectZones([...selectZones, name]);
     }
     setClusterList(
-      getNewClusterList(clusterList, name, checked, { name: clusterName }),
+      getNewClusterList(clusterList, name, checked, { name: clusterResourceName }),
     );
   };
 
   const targetZoneList = clusterList
-    .filter((cluster) => cluster.clusterName === clusterName)[0]
+    .filter((cluster) => cluster.name === clusterResourceName)[0]
     ?.topology.map((zone) => ({ zone: zone.zone, checked: zone.checked }));
-
+    
   useEffect(() => {
     if (essentialParameter) {
       setMinMemory(essentialParameter.minPoolMemory / (1 << 30));

--- a/ui/src/pages/Tenant/Detail/Overview/index.tsx
+++ b/ui/src/pages/Tenant/Detail/Overview/index.tsx
@@ -233,10 +233,10 @@ export default function TenantOverview() {
     tenantDetail: API.TenantBasicInfo | undefined,
   ) => {
     if (!tenantDetail) return clusters;
-    const { clusterName } = tenantDetail.info;
+    const { clusterResourceName } = tenantDetail.info;
     const { replicas } = tenantDetail;
     const cluster = clusters.find(
-      (cluster) => cluster.clusterName === clusterName,
+      (cluster) => cluster.clusterName === clusterResourceName,
     );
     if (cluster && cluster.topology) {
       cluster.topology = cluster.topology.filter((zone) =>
@@ -259,7 +259,7 @@ export default function TenantOverview() {
   useEffect(() => {
     if (tenantDetail && clusterList) {
       const cluster = clusterList.find(
-        (cluster) => cluster.clusterName === tenantDetail.info.clusterName,
+        (cluster) => cluster.name === tenantDetail.info.clusterResourceName,
       );
       if (cluster) {
         const { name, namespace } = cluster;
@@ -300,7 +300,7 @@ export default function TenantOverview() {
           defaultValueForUnitDetail={{
             clusterList:formatClustersTopology(clusterList,tenantDetail),
             essentialParameter,
-            clusterName:tenantDetail?.info.clusterName,
+            clusterResourceName:tenantDetail?.info.clusterResourceName,
             setClusterList,
           }}
         />

--- a/ui/src/pages/Tenant/Detail/Overview/index.tsx
+++ b/ui/src/pages/Tenant/Detail/Overview/index.tsx
@@ -236,7 +236,7 @@ export default function TenantOverview() {
     const { clusterResourceName } = tenantDetail.info;
     const { replicas } = tenantDetail;
     const cluster = clusters.find(
-      (cluster) => cluster.clusterName === clusterResourceName,
+      (cluster) => cluster.name === clusterResourceName,
     );
     if (cluster && cluster.topology) {
       cluster.topology = cluster.topology.filter((zone) =>

--- a/ui/src/pages/Tenant/Detail/Topo/index.tsx
+++ b/ui/src/pages/Tenant/Detail/Topo/index.tsx
@@ -16,7 +16,7 @@ export default function Topo() {
       {tenantTopoData && (
         <TopoComponent
           tenantReplicas={tenantTopoData.replicas}
-          clusterNameOfKubectl={tenantTopoData.info.clusterName}
+          clusterNameOfKubectl={tenantTopoData.info.clusterResourceName}
           namespace={tenantTopoData.info.namespace}
           header={
             <BasicInfo

--- a/ui/src/pages/Tenant/helper.ts
+++ b/ui/src/pages/Tenant/helper.ts
@@ -198,7 +198,7 @@ export const getNewClusterList = (
   for (let cluster of _clusterList) {
     if (
       cluster.clusterId === target.id ||
-      cluster.clusterName === target.name
+      cluster.name === target.name
     ) {
       cluster.topology.forEach((zoneItem) => {
         if (zoneItem.zone === zone) {

--- a/ui/src/services/tenant.ts
+++ b/ui/src/services/tenant.ts
@@ -32,7 +32,7 @@ export async function getTenant({
   });
   let infoKeys = [
     'charset',
-    'clusterName',
+    'clusterResourceName',
     'tenantName',
     'tenantRole',
     'unitNumber',

--- a/ui/src/services/typings.d.ts
+++ b/ui/src/services/typings.d.ts
@@ -399,7 +399,7 @@ declare namespace API {
 
   type InfoType = {
     charset: string;
-    clusterName: string;
+    clusterResourceName: string;
     tenantName: string;
     tenantRole: TenantRole;
     unitNumber: number;


### PR DESCRIPTION
## Summary
To avoid ambiguity, use the field clusterResourceName instead of clusterName.
