### PR TITLE
Fixed mismatched standby tenant name and resource name

### DIFF
--- a/internal/resource/obtenant/obtenant_task.go
+++ b/internal/resource/obtenant/obtenant_task.go
@@ -16,6 +16,7 @@ package obtenant
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -219,7 +220,14 @@ func CreateEmptyStandbyTenant(m *OBTenantManager) tasktypes.TaskError {
 	if err != nil {
 		return err
 	}
-	restoreSource, err := resourceutils.GetTenantRestoreSource(m.Ctx, m.Client, m.Logger, con, m.OBTenant.Namespace, *m.OBTenant.Spec.Source.Tenant)
+	ns := m.OBTenant.GetNamespace()
+	tenantCRName := *m.OBTenant.Spec.Source.Tenant
+	splits := strings.Split(*m.OBTenant.Spec.Source.Tenant, "/")
+	if len(splits) == 2 {
+		ns = splits[0]
+		tenantCRName = splits[1]
+	}
+	restoreSource, err := resourceutils.GetTenantRestoreSource(m.Ctx, m.Client, m.Logger, con, ns, tenantCRName)
 	if err != nil {
 		return err
 	}

--- a/internal/resource/utils/util.go
+++ b/internal/resource/utils/util.go
@@ -379,7 +379,7 @@ func GetTenantRestoreSource(ctx context.Context, clt client.Client, logger *logr
 		}
 	} else {
 		// Get ip_list from primary tenant
-		aps, err := con.ListTenantAccessPoints(tenantCR)
+		aps, err := con.ListTenantAccessPoints(primary.Spec.TenantName)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

1. Fixed a bug that caused by mismatched names
2. Added support for setting up inter-namespace standby tenant
