### PR TITLE
fix:Limit selecting cluster

### DIFF
--- a/ui/src/components/customModal/ModifyUnitDetailModal.tsx
+++ b/ui/src/components/customModal/ModifyUnitDetailModal.tsx
@@ -504,15 +504,6 @@ export default function ModifyUnitDetailModal({
             <Row gutter={24}>
               <Col>
                 <Form.Item
-                  rules={[
-                    {
-                      required: true,
-                      message: intl.formatMessage({
-                        id: 'Dashboard.components.customModal.ModifyUnitDetailModal.EnterMiniops',
-                        defaultMessage: '请输入 minIops',
-                      }),
-                    },
-                  ]}
                   label="min iops"
                   name={['unitConfig', 'minIops']}
                 >
@@ -527,15 +518,6 @@ export default function ModifyUnitDetailModal({
               </Col>
               <Col>
                 <Form.Item
-                  rules={[
-                    {
-                      required: true,
-                      message: intl.formatMessage({
-                        id: 'Dashboard.components.customModal.ModifyUnitDetailModal.EnterMaxiops',
-                        defaultMessage: '请输入 maxIops',
-                      }),
-                    },
-                  ]}
                   label="max iops"
                   name={['unitConfig', 'maxIops']}
                 >
@@ -556,15 +538,6 @@ export default function ModifyUnitDetailModal({
                 id: 'Dashboard.components.customModal.ModifyUnitDetailModal.IopsWeight',
                 defaultMessage: 'iops权重',
               })}
-              rules={[
-                {
-                  required: true,
-                  message: intl.formatMessage({
-                    id: 'Dashboard.components.customModal.ModifyUnitDetailModal.EnterIopsWeight',
-                    defaultMessage: '请输入 iops权重',
-                  }),
-                },
-              ]}
               name={['unitConfig', 'iopsWeight']}
             >
               <InputNumber

--- a/ui/src/i18n/strings/en-US.json
+++ b/ui/src/i18n/strings/en-US.json
@@ -690,5 +690,6 @@
   "Dashboard.components.customModal.ModifyPasswordModal.OperationSucceeded": "Operation succeeded!",
   "Dashboard.components.customModal.ScaleModal.OperationSucceeded": "Operation succeeded!",
   "Dashboard.components.customModal.SwitchTenantModal.OperationSucceeded": "Operation succeeded",
-  "Dashboard.components.customModal.UpgradeModal.OperationSucceeded": "Operation succeeded!"
+  "Dashboard.components.customModal.UpgradeModal.OperationSucceeded": "Operation succeeded!",
+  "Dashboard.Tenant.New.BasicInfo.PleaseSelect": "Please select"
 }

--- a/ui/src/i18n/strings/zh-CN.json
+++ b/ui/src/i18n/strings/zh-CN.json
@@ -690,5 +690,6 @@
   "Dashboard.components.customModal.ModifyPasswordModal.OperationSucceeded": "操作成功！",
   "Dashboard.components.customModal.ScaleModal.OperationSucceeded": "操作成功！",
   "Dashboard.components.customModal.SwitchTenantModal.OperationSucceeded": "操作成功",
-  "Dashboard.components.customModal.UpgradeModal.OperationSucceeded": "操作成功！"
+  "Dashboard.components.customModal.UpgradeModal.OperationSucceeded": "操作成功！",
+  "Dashboard.Tenant.New.BasicInfo.PleaseSelect": "请选择"
 }

--- a/ui/src/pages/Tenant/Detail/Overview/Replicas.tsx
+++ b/ui/src/pages/Tenant/Detail/Overview/Replicas.tsx
@@ -9,6 +9,7 @@ import styles from './index.less';
 
 interface ReplicasProps {
   replicaList: API.ReplicaDetailType[];
+  tenantStatus: string;
   refreshTenant: () => void;
   openOperateModal: (type: API.ModalType) => void;
   setEditZone: React.Dispatch<React.SetStateAction<string>>;
@@ -50,6 +51,7 @@ export default function Replicas({
   setEditZone,
   operateType,
   cluster,
+  tenantStatus
 }: ReplicasProps) {
   const { ns, name } = useParams();
   const sortKeys = (keys: string[]) => {
@@ -101,7 +103,7 @@ export default function Replicas({
         extra={
           <Button
             type="primary"
-            disabled={cluster?.topology?.length === replicaList.length}
+            disabled={cluster?.topology?.length === replicaList.length || tenantStatus !== 'running'}
             onClick={addResourcePool}
           >
             {intl.formatMessage({
@@ -131,6 +133,7 @@ export default function Replicas({
                 <div>
                   <Button
                     onClick={() => editResourcePool(replica.zone)}
+                    disabled={tenantStatus !== 'running'}
                     type="link"
                   >
                     {intl.formatMessage({
@@ -153,7 +156,7 @@ export default function Replicas({
                       });
                     }}
                     disabled={
-                      replicaList.length === 2 || replicaList.length === 1
+                      replicaList.length <= 2 || tenantStatus !== 'running'
                     }
                     type="link"
                     danger

--- a/ui/src/pages/Tenant/Detail/Overview/index.tsx
+++ b/ui/src/pages/Tenant/Detail/Overview/index.tsx
@@ -320,6 +320,7 @@ export default function TenantOverview() {
                 clusterList,
                 tenantDetail.info.clusterResourceName,
               )}
+              tenantStatus={tenantDetail?.info?.status}
               setEditZone={setEditZone}
               editZone={editZone}
               operateType={operateTypeRef}

--- a/ui/src/pages/Tenant/New/BasicInfo.tsx
+++ b/ui/src/pages/Tenant/New/BasicInfo.tsx
@@ -1,8 +1,8 @@
 import InputNumber from '@/components/InputNumber';
 import PasswordInput from '@/components/PasswordInput';
-import { RESOURCE_NAME_REG,TZ_NAME_REG } from '@/constants';
+import { RESOURCE_NAME_REG, TZ_NAME_REG } from '@/constants';
 import { intl } from '@/utils/intl';
-import { Card,Col,Form,Input,Row,Select } from 'antd';
+import { Card, Col, Form, Input, Row, Select } from 'antd';
 import type { FormInstance } from 'antd/lib/form';
 
 interface BasicInfoProps {
@@ -25,7 +25,7 @@ export default function BasicInfo({
     .map((cluster) => ({
       value: cluster.clusterId,
       label: cluster.name,
-      status: cluster.status
+      status: cluster.status,
     }));
   const selectClusterChange = (id: number) => {
     setSelectClusterId(id);
@@ -56,7 +56,10 @@ export default function BasicInfo({
             })}
           >
             <Select
-              placeholder="请选择"
+              placeholder={intl.formatMessage({
+                id: 'Dashboard.Tenant.New.BasicInfo.PleaseSelect',
+                defaultMessage: '请选择',
+              })}
               onChange={(value) => selectClusterChange(value)}
               optionLabelProp="selectLabel"
               options={clusterOptions.map((option) => ({
@@ -185,10 +188,10 @@ export default function BasicInfo({
           </Form.Item>
         </Col>
         {/* <Col span={8}>
-             <Form.Item name={["charset"]} label="字符集">
-               <Select />
-             </Form.Item>
-            </Col> */}
+              <Form.Item name={["charset"]} label="字符集">
+                <Select />
+              </Form.Item>
+             </Col> */}
       </Row>
     </Card>
   );

--- a/ui/src/pages/Tenant/New/BasicInfo.tsx
+++ b/ui/src/pages/Tenant/New/BasicInfo.tsx
@@ -1,8 +1,8 @@
 import InputNumber from '@/components/InputNumber';
 import PasswordInput from '@/components/PasswordInput';
-import { RESOURCE_NAME_REG, TZ_NAME_REG } from '@/constants';
+import { RESOURCE_NAME_REG,TZ_NAME_REG } from '@/constants';
 import { intl } from '@/utils/intl';
-import { Card, Col, Form, Input, Row, Select } from 'antd';
+import { Card,Col,Form,Input,Row,Select } from 'antd';
 import type { FormInstance } from 'antd/lib/form';
 
 interface BasicInfoProps {
@@ -25,6 +25,7 @@ export default function BasicInfo({
     .map((cluster) => ({
       value: cluster.clusterId,
       label: cluster.name,
+      status: cluster.status
     }));
   const selectClusterChange = (id: number) => {
     setSelectClusterId(id);
@@ -55,8 +56,25 @@ export default function BasicInfo({
             })}
           >
             <Select
+              placeholder="请选择"
               onChange={(value) => selectClusterChange(value)}
-              options={clusterOptions}
+              optionLabelProp="selectLabel"
+              options={clusterOptions.map((option) => ({
+                value: option.value,
+                selectLabel: option.label,
+                disabled: option.status !== 'running',
+                label: (
+                  <div
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                    }}
+                  >
+                    <span>{option.label}</span>
+                    <span>{option.status}</span>
+                  </div>
+                ),
+              }))}
             />
           </Form.Item>
         </Col>


### PR DESCRIPTION
## Summary
1. Editing or adding a new resource pool allows iops related parameters to be empty.
2. Limit the resource pool operation when the status is not running tenant.
3. When creating a tenant, restrict the selection of clusters whose status is not running.

![image](https://github.com/oceanbase/ob-operator/assets/62841398/5325871b-9335-4bb2-bfe6-93560c2263c2)
