### PR TITLE
Added timeout for infinitely looping task

### DIFF
--- a/internal/clients/obcluster.go
+++ b/internal/clients/obcluster.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/oceanbase/ob-operator/api/v1alpha1"
 	"github.com/oceanbase/ob-operator/internal/clients/schema"
@@ -32,9 +33,8 @@ const (
 	PasswordKey = "password"
 )
 
-// TODO: generate random password
 func generatePassword() string {
-	return "pass"
+	return rand.String(16)
 }
 
 func createPasswordSecret(ctx context.Context, namespace, name, password string) error {

--- a/internal/const/oceanbase/time.go
+++ b/internal/const/oceanbase/time.go
@@ -37,6 +37,7 @@ const (
 	LocalityChangeTimeoutSeconds  = 86400 // 1 day
 	DefaultStateWaitTimeout       = 1800
 	TimeConsumingStateWaitTimeout = 3600
+	WaitForJobTimeoutSeconds      = 7200
 	ServerDeleteTimeoutSeconds    = 604800 // 7 days
 )
 

--- a/internal/resource/obtenant/obtenant_task.go
+++ b/internal/resource/obtenant/obtenant_task.go
@@ -30,7 +30,6 @@ import (
 	"github.com/oceanbase/ob-operator/api/v1alpha1"
 	oceanbaseconst "github.com/oceanbase/ob-operator/internal/const/oceanbase"
 	resourceutils "github.com/oceanbase/ob-operator/internal/resource/utils"
-	"github.com/oceanbase/ob-operator/pkg/oceanbase-sdk/const/config"
 	"github.com/oceanbase/ob-operator/pkg/oceanbase-sdk/const/status/tenant"
 	"github.com/oceanbase/ob-operator/pkg/oceanbase-sdk/model"
 	"github.com/oceanbase/ob-operator/pkg/task/builder"
@@ -341,31 +340,27 @@ func CreateTenantRestoreJobCR(m *OBTenantManager) tasktypes.TaskError {
 
 func WatchRestoreJobToFinish(m *OBTenantManager) tasktypes.TaskError {
 	var err error
-	// Tenant restoring is in common quite a slow process, so we need to wait for a longer time
-	timeout := time.NewTimer(time.Second * oceanbaseconst.LocalityChangeTimeoutSeconds)
-	defer timeout.Stop()
-loop:
-	for {
-		select {
-		case <-timeout.C:
-			return errors.New("Timeout when waiting for restore job to finish")
-		default:
-			runningRestore := &v1alpha1.OBTenantRestore{}
-			err = m.Client.Get(m.Ctx, types.NamespacedName{
-				Namespace: m.OBTenant.GetNamespace(),
-				Name:      m.OBTenant.Name + "-restore",
-			}, runningRestore)
-			if err != nil {
-				return err
-			}
-			if runningRestore.Status.Status == constants.RestoreJobSuccessful {
-				break loop
-			} else if runningRestore.Status.Status == constants.RestoreJobFailed {
-				m.Recorder.Event(m.OBTenant, "RestoreJobFailed", "", "Restore job failed")
-				return errors.New("Restore job failed")
-			}
-			time.Sleep(5 * time.Second)
+	check := func() (bool, error) {
+		runningRestore := &v1alpha1.OBTenantRestore{}
+		err = m.Client.Get(m.Ctx, types.NamespacedName{
+			Namespace: m.OBTenant.GetNamespace(),
+			Name:      m.OBTenant.Name + "-restore",
+		}, runningRestore)
+		if err != nil {
+			return false, err
 		}
+		if runningRestore.Status.Status == constants.RestoreJobSuccessful {
+			return true, nil
+		} else if runningRestore.Status.Status == constants.RestoreJobFailed {
+			m.Recorder.Event(m.OBTenant, "RestoreJobFailed", "", "Restore job failed")
+			return false, errors.New("Restore job failed")
+		}
+		return false, nil
+	}
+	// Tenant restoring is in common quite a slow process, so we need to wait for a longer time
+	err = resourceutils.CheckJobWithTimeout(check, time.Second*oceanbaseconst.LocalityChangeTimeoutSeconds)
+	if err != nil {
+		return errors.Wrap(err, "Failed to wait for restore job to finish")
 	}
 	tenantWhiteListMap.Store(m.OBTenant.Spec.TenantName, m.OBTenant.Spec.ConnectWhiteList)
 	m.Recorder.Event(m.OBTenant, "RestoreJobFinished", "", "Restore job finished successfully")
@@ -536,26 +531,19 @@ func CheckAndApplyLocality(m *OBTenantManager) tasktypes.TaskError {
 			return err
 		}
 	}
-	m.Logger.V(oceanbaseconst.LogLevelDebug).Info("Wait For Tenant 'ALTER_TENANT' job of adding pool task", "tenantName", tenantName)
-	timeout := time.NewTimer(time.Second * oceanbaseconst.DefaultStateWaitTimeout)
-	defer timeout.Stop()
-loop:
-	for {
-		select {
-		case <-timeout.C:
-			return errors.New("Timeout when waiting for 'ALTER_TENANT' Job of adding pool task to finish")
-		default:
-			exist, err := oceanbaseOperationManager.CheckRsJobExistByTenantID(m.OBTenant.Status.TenantRecordInfo.TenantID)
-			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("Get RsJob %s", tenantName))
-			}
-			if !exist {
-				break loop
-			}
-			time.Sleep(config.PollingJobSleepTime)
+	m.Logger.V(oceanbaseconst.LogLevelDebug).Info("Wait for tenant 'ALTER_TENANT' job of adding pool task", "tenantName", tenantName)
+	check := func() (bool, error) {
+		exist, err := oceanbaseOperationManager.CheckRsJobExistByTenantID(m.OBTenant.Status.TenantRecordInfo.TenantID)
+		if err != nil {
+			return false, errors.Wrap(err, fmt.Sprintf("Get RsJob %s", tenantName))
 		}
+		return !exist, nil
 	}
-	m.Logger.V(oceanbaseconst.LogLevelDebug).Info("'ALTER_TENANT' Job of adding pool task succeeded", "tenantName", tenantName)
+	err = resourceutils.CheckJobWithTimeout(check)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("Failed to wait for 'ALTER_TENANT' job of adding pool task to finish %s", tenantName))
+	}
+	m.Logger.V(oceanbaseconst.LogLevelDebug).Info("'ALTER_TENANT' job of adding pool task succeeded", "tenantName", tenantName)
 	return nil
 }
 

--- a/internal/resource/obzone/obzone_task.go
+++ b/internal/resource/obzone/obzone_task.go
@@ -231,7 +231,7 @@ func OBClusterHealthCheck(m *OBZoneManager) tasktypes.TaskError {
 	if err != nil {
 		return errors.Wrap(err, "Get obcluster from K8s")
 	}
-	_ = resourceutils.ExecuteUpgradeScript(m.Client, m.Logger, obcluster, oceanbaseconst.UpgradeHealthCheckerScriptPath, "")
+	_ = resourceutils.ExecuteUpgradeScript(m.Ctx, m.Client, m.Logger, obcluster, oceanbaseconst.UpgradeHealthCheckerScriptPath, "")
 	return nil
 }
 
@@ -241,7 +241,7 @@ func OBZoneHealthCheck(m *OBZoneManager) tasktypes.TaskError {
 		return errors.Wrap(err, "Get obcluster from K8s")
 	}
 	zoneOpt := fmt.Sprintf("-z '%s'", m.OBZone.Spec.Topology.Zone)
-	_ = resourceutils.ExecuteUpgradeScript(m.Client, m.Logger, obcluster, oceanbaseconst.UpgradeHealthCheckerScriptPath, zoneOpt)
+	_ = resourceutils.ExecuteUpgradeScript(m.Ctx, m.Client, m.Logger, obcluster, oceanbaseconst.UpgradeHealthCheckerScriptPath, zoneOpt)
 	return nil
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

1. If a user set a wrong target image when upgrading OBCluster, created job will never end or be deleted. This PR added a long timeout and OwnerReference for infinitely looping task to avoid memory leak.
2. Generated truly random passwords instead of hardcode plain password for 3 underwater users when creating OBCluster with dashboard.
