### PR TITLE
fix:Correct the way resources are obtained

### DIFF
--- a/ui/src/pages/Tenant/helper.ts
+++ b/ui/src/pages/Tenant/helper.ts
@@ -191,17 +191,17 @@ export function findMinParameter(
       };
     } else {
       result = {
-        maxCPU: Math.max(
+        maxCPU: Math.min(
           result.maxCPU!,
-          essentialParameter[zone]['availableCPU'],
+          essentialParameter.obZoneResourceMap[zone]['availableCPU'],
         ),
-        maxLogDisk: Math.max(
+        maxLogDisk: Math.min(
           result.maxLogDisk!,
-          essentialParameter[zone]['availableLogDisk'],
+          essentialParameter.obZoneResourceMap[zone]['availableLogDisk'],
         ),
-        maxMemory: Math.max(
+        maxMemory: Math.min(
           result.maxMemory!,
-          essentialParameter[zone]['availableMemory'],
+          essentialParameter.obZoneResourceMap[zone]['availableMemory'],
         ),
       };
     }

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -442,7 +442,6 @@ export async function getEssentialParameters({
   ns,
   name,
 }: API.NamespaceAndName): Promise<API.EssentialParametersTypeResponse> {
-  // return request(`${obClusterPrefix}/${ns}/${name}/resource-usages`);
   const r = await request(`${obClusterPrefix}/${ns}/${name}/resource-usages`);
   const formatResourceAttr = ['availableDataDisk','availableLogDisk','availableMemory']
   if(r.successful){
@@ -450,17 +449,11 @@ export async function getEssentialParameters({
     r.data.obServerResources.forEach((item)=>{
       for(let attr of formatResourceAttr){
         item[attr] = item[attr] / (1<<30)
-        // if(attr === 'availableMemory' && item.obZone === 'zone1'){
-        //   item[attr] = 3
-        // }
       }
     })
     Object.keys(r.data.obZoneResourceMap).forEach((key)=>{
       for(let attr of formatResourceAttr){
         r.data.obZoneResourceMap[key][attr] = r.data.obZoneResourceMap[key][attr] / (1 << 30);
-        // if(attr === 'availableMemory' && key === 'zone1'){
-        //   r.data.obZoneResourceMap[key][attr] = 3
-        // }
       }
     }) 
     return r


### PR DESCRIPTION
## Summary
1. The corresponding resource should be obtained through the `obZoneResourceMap` attribute.
2. Make sure the input values are less than the available resource values.