### PR TITLE
Added environment checking flow

### DIFF
--- a/internal/const/cmd/exit_code.go
+++ b/internal/const/cmd/exit_code.go
@@ -15,8 +15,9 @@ package cmd
 type ExitCode int
 
 const (
-	ExitCodeOK         ExitCode = 0
-	ExitCodeErr        ExitCode = 1
-	ExitCodeBadArgs    ExitCode = 2
-	ExitCodeNotSupport ExitCode = 10
+	ExitCodeOK          ExitCode = 0
+	ExitCodeErr         ExitCode = 1
+	ExitCodeBadArgs     ExitCode = 2
+	ExitCodeNotExecuted ExitCode = 4
+	ExitCodeNotSupport  ExitCode = 10
 )

--- a/internal/resource/obcluster/names.go
+++ b/internal/resource/obcluster/names.go
@@ -63,4 +63,5 @@ const (
 	tScaleUpOBZones             ttypes.TaskName = "scale up obzones"
 	tExpandPVC                  ttypes.TaskName = "expand pvc"
 	tMountBackupVolume          ttypes.TaskName = "mount backup volume"
+	tCheckEnvironment           ttypes.TaskName = "check environment"
 )

--- a/internal/resource/obcluster/obcluster_flow.go
+++ b/internal/resource/obcluster/obcluster_flow.go
@@ -22,7 +22,7 @@ func genMigrateOBClusterFromExistingFlow(_ *OBClusterManager) *tasktypes.TaskFlo
 	return &tasktypes.TaskFlow{
 		OperationContext: &tasktypes.OperationContext{
 			Name:         fMigrateOBClusterFromExisting,
-			Tasks:        []tasktypes.TaskName{tCheckMigration, tCheckImageReady, tCheckClusterMode, tCheckAndCreateUserSecrets, tCreateOBZone, tWaitOBZoneRunning, tCreateUsers, tMaintainOBParameter, tCreateServiceForMonitor, tCreateOBClusterService},
+			Tasks:        []tasktypes.TaskName{tCheckMigration, tCheckImageReady, tCheckEnvironment, tCheckClusterMode, tCheckAndCreateUserSecrets, tCreateOBZone, tWaitOBZoneRunning, tCreateUsers, tMaintainOBParameter, tCreateServiceForMonitor, tCreateOBClusterService},
 			TargetStatus: clusterstatus.Running,
 			OnFailure: tasktypes.FailureRule{
 				NextTryStatus: clusterstatus.Failed,
@@ -35,7 +35,7 @@ func genBootstrapOBClusterFlow(_ *OBClusterManager) *tasktypes.TaskFlow {
 	return &tasktypes.TaskFlow{
 		OperationContext: &tasktypes.OperationContext{
 			Name:         fBootstrapOBCluster,
-			Tasks:        []tasktypes.TaskName{tCheckImageReady, tCheckClusterMode, tCheckAndCreateUserSecrets, tCreateOBZone, tWaitOBZoneBootstrapReady, tBootstrap},
+			Tasks:        []tasktypes.TaskName{tCheckImageReady, tCheckEnvironment, tCheckClusterMode, tCheckAndCreateUserSecrets, tCreateOBZone, tWaitOBZoneBootstrapReady, tBootstrap},
 			TargetStatus: clusterstatus.Bootstrapped,
 			OnFailure: tasktypes.FailureRule{
 				NextTryStatus: clusterstatus.Failed,

--- a/internal/resource/obcluster/obcluster_task_gen.go
+++ b/internal/resource/obcluster/obcluster_task_gen.go
@@ -29,4 +29,5 @@ func init() {
 	taskMap.Register(tMountBackupVolume, MountBackupVolume)
 	taskMap.Register(tWaitOBZoneBootstrapReady, WaitOBZoneBootstrapReady)
 	taskMap.Register(tWaitOBZoneRunning, WaitOBZoneRunning)
+	taskMap.Register(tCheckEnvironment, CheckEnvironment)
 }

--- a/internal/resource/utils/util.go
+++ b/internal/resource/utils/util.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"time"
 
+	cmdconst "github.com/oceanbase/ob-operator/internal/const/cmd"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	batchv1 "k8s.io/api/batch/v1"
@@ -220,7 +222,7 @@ func RunJob(ctx context.Context, c client.Client, logger *logr.Logger, namespace
 
 	err = c.Create(ctx, &job)
 	if err != nil {
-		return "", exitCode, errors.Wrapf(err, "failed to create job of image: %s", image)
+		return "", int32(cmdconst.ExitCodeNotExecuted), errors.Wrapf(err, "failed to create job of image: %s", image)
 	}
 
 	var jobObject *batchv1.Job
@@ -243,7 +245,7 @@ func RunJob(ctx context.Context, c client.Client, logger *logr.Logger, namespace
 		LabelSelector: fmt.Sprintf("job-name=%s", fullJobName),
 	})
 	if err != nil || len(podList.Items) == 0 {
-		return "", 1, errors.Wrapf(err, "failed to get pods of job %s", jobName)
+		return "", int32(cmdconst.ExitCodeNotExecuted), errors.Wrapf(err, "failed to get pods of job %s", jobName)
 	}
 	var outputBuffer bytes.Buffer
 	podLogOpts := corev1.PodLogOptions{}

--- a/internal/resource/utils/util.go
+++ b/internal/resource/utils/util.go
@@ -110,7 +110,7 @@ func GetTenantRootOperationClient(c client.Client, logger *logr.Logger, obcluste
 			return rootClient, nil
 		}
 	}
-	return nil, errors.Errorf("Can not get root operation client of tenant %s in obcluster %s after checked all server", tenantName, obcluster.Name)
+	return nil, errors.Errorf("Can not get root operation client of tenant %s in obcluster %s after checked all servers", tenantName, obcluster.Name)
 }
 
 func getSysClientFromSourceCluster(c client.Client, logger *logr.Logger, obcluster *v1alpha1.OBCluster, userName, tenantName, secretName string) (*operation.OceanbaseOperationManager, error) {
@@ -180,10 +180,10 @@ func getSysClient(c client.Client, logger *logr.Logger, obcluster *v1alpha1.OBCl
 			return sysClient, nil
 		}
 	}
-	return nil, errors.Errorf("Can not get oceanbase operation manager of obcluster %s after checked all server", obcluster.Name)
+	return nil, errors.Errorf("Can not get oceanbase operation manager of obcluster %s after checked all servers", obcluster.Name)
 }
 
-func GetJob(c client.Client, namespace string, jobName string) (*batchv1.Job, error) {
+func GetJob(ctx context.Context, c client.Client, namespace string, jobName string) (*batchv1.Job, error) {
 	job := &batchv1.Job{}
 	err := c.Get(context.Background(), types.NamespacedName{
 		Namespace: namespace,
@@ -192,7 +192,7 @@ func GetJob(c client.Client, namespace string, jobName string) (*batchv1.Job, er
 	return job, err
 }
 
-func RunJob(c client.Client, logger *logr.Logger, namespace string, jobName string, image string, cmd string) (string, error) {
+func RunJob(ctx context.Context, c client.Client, logger *logr.Logger, namespace string, jobName string, image string, cmd string) (output string, exitCode int32, err error) {
 	fullJobName := fmt.Sprintf("%s-%s", jobName, rand.String(6))
 	var backoffLimit int32
 	var ttl int32 = 300
@@ -218,15 +218,14 @@ func RunJob(c client.Client, logger *logr.Logger, namespace string, jobName stri
 		},
 	}
 
-	err := c.Create(context.Background(), &job)
+	err = c.Create(ctx, &job)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to create job of image: %s", image)
+		return "", exitCode, errors.Wrapf(err, "failed to create job of image: %s", image)
 	}
 
-	output := ""
 	var jobObject *batchv1.Job
 	for i := 0; i < oceanbaseconst.CheckJobMaxRetries; i++ {
-		jobObject, err = GetJob(c, namespace, fullJobName)
+		jobObject, err = GetJob(ctx, c, namespace, fullJobName)
 		if err != nil {
 			logger.Error(err, "Failed to get job")
 			// return errors.Wrapf(err, "Failed to get run upgrade script job for obcluster %s", obcluster.Name)
@@ -239,20 +238,25 @@ func RunJob(c client.Client, logger *logr.Logger, namespace string, jobName stri
 		}
 		time.Sleep(time.Second * oceanbaseconst.CheckJobInterval)
 	}
+	clientSet := k8sclient.GetClient()
+	podList, err := clientSet.ClientSet.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("job-name=%s", fullJobName),
+	})
+	if err != nil || len(podList.Items) == 0 {
+		return "", 1, errors.Wrapf(err, "failed to get pods of job %s", jobName)
+	}
+	var outputBuffer bytes.Buffer
+	podLogOpts := corev1.PodLogOptions{}
+	pod := podList.Items[0]
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name == "job-runner" {
+			exitCode = cs.State.Terminated.ExitCode
+		}
+	}
 	if jobObject.Status.Succeeded == 1 {
 		logger.V(oceanbaseconst.LogLevelDebug).Info("Job succeeded", "job", fullJobName)
-		clientSet := k8sclient.GetClient()
-		podList, err := clientSet.ClientSet.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("job-name=%s", fullJobName),
-		})
-		if err != nil || len(podList.Items) == 0 {
-			return "", errors.Wrapf(err, "failed to get pods of job %s", jobName)
-		}
-		var outputBuffer bytes.Buffer
-		podLogOpts := corev1.PodLogOptions{}
-		pod := podList.Items[0]
 		res := clientSet.ClientSet.CoreV1().Pods(namespace).GetLogs(pod.Name, &podLogOpts)
-		logs, err := res.Stream(context.TODO())
+		logs, err := res.Stream(ctx)
 		if err != nil {
 			logger.Error(err, "Failed to get job logs")
 		} else {
@@ -265,9 +269,9 @@ func RunJob(c client.Client, logger *logr.Logger, namespace string, jobName stri
 		}
 	} else {
 		logger.V(oceanbaseconst.LogLevelDebug).Info("Job failed", "job", fullJobName)
-		return "", errors.Wrapf(err, "Failed to run job %s", fullJobName)
+		return "", exitCode, errors.Wrapf(err, "Failed to run job %s", fullJobName)
 	}
-	return output, nil
+	return output, exitCode, nil
 }
 
 func ExecuteUpgradeScript(ctx context.Context, c client.Client, logger *logr.Logger, obcluster *v1alpha1.OBCluster, filepath string, extraOpt string) error {
@@ -330,7 +334,7 @@ func ExecuteUpgradeScript(ctx context.Context, c client.Client, logger *logr.Log
 
 	var jobObject *batchv1.Job
 	check := func() (bool, error) {
-		jobObject, err = GetJob(c, obcluster.Namespace, jobName)
+		jobObject, err = GetJob(ctx, c, obcluster.Namespace, jobName)
 		if err != nil {
 			return false, errors.Wrapf(err, "Failed to get run upgrade script job for obcluster %s", obcluster.Name)
 		}

--- a/internal/resource/utils/util.go
+++ b/internal/resource/utils/util.go
@@ -185,7 +185,7 @@ func getSysClient(c client.Client, logger *logr.Logger, obcluster *v1alpha1.OBCl
 
 func GetJob(ctx context.Context, c client.Client, namespace string, jobName string) (*batchv1.Job, error) {
 	job := &batchv1.Job{}
-	err := c.Get(context.Background(), types.NamespacedName{
+	err := c.Get(ctx, types.NamespacedName{
 		Namespace: namespace,
 		Name:      jobName,
 	}, job)


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

1. Refactored `resourceutils`.`RunJob` to return exit code of a job
2. Added flow for checking support for `fallocate` syscall