### PR TITLE
fix #325 optimize observer recover logic

### DIFF
--- a/internal/resource/observer/names.go
+++ b/internal/resource/observer/names.go
@@ -24,7 +24,6 @@ const (
 	fDeleteOBServerFinalizer        ttypes.FlowName = "delete observer finalizer"
 	fUpgradeOBServer                ttypes.FlowName = "upgrade observer"
 	fRecoverOBServer                ttypes.FlowName = "recover observer"
-	fAddServerInOB                  ttypes.FlowName = "add observer in ob"
 	fAnnotateOBServerPod            ttypes.FlowName = "annotate observer pod"
 	fScaleUpOBServer                ttypes.FlowName = "scale up observer"
 	fExpandPVC                      ttypes.FlowName = "expand pvc for observer"

--- a/internal/resource/observer/observer_flow.go
+++ b/internal/resource/observer/observer_flow.go
@@ -75,21 +75,11 @@ func genRecoverOBServerFlow(_ *OBServerManager) *tasktypes.TaskFlow {
 	return &tasktypes.TaskFlow{
 		OperationContext: &tasktypes.OperationContext{
 			Name:         fRecoverOBServer,
-			Tasks:        []tasktypes.TaskName{tCreateOBPod, tWaitOBServerReady, tWaitOBServerActiveInCluster},
+			Tasks:        []tasktypes.TaskName{tCreateOBPod, tWaitOBServerReady, tAddServer, tWaitOBServerActiveInCluster},
 			TargetStatus: serverstatus.Running,
 			OnFailure: tasktypes.FailureRule{
 				Strategy: strategy.RetryFromCurrent,
 			},
-		},
-	}
-}
-
-func genAddServerInOBFlow(_ *OBServerManager) *tasktypes.TaskFlow {
-	return &tasktypes.TaskFlow{
-		OperationContext: &tasktypes.OperationContext{
-			Name:         fAddServerInOB,
-			Tasks:        []tasktypes.TaskName{tAddServer, tWaitOBServerActiveInCluster},
-			TargetStatus: serverstatus.Running,
 		},
 	}
 }

--- a/internal/resource/observer/observer_manager.go
+++ b/internal/resource/observer/observer_manager.go
@@ -113,12 +113,7 @@ func (m *OBServerManager) UpdateStatus() error {
 		// 1. Check status of observer in OB database
 		if m.OBServer.Status.Status == serverstatus.Running {
 			m.Logger.V(oceanbaseconst.LogLevelDebug).Info("Check observer in obcluster")
-			observer, err := m.getCurrentOBServerFromOB()
-			if err != nil {
-				m.Logger.V(oceanbaseconst.LogLevelDebug).Info("Get observer failed, check next time")
-			} else if observer == nil {
-				m.OBServer.Status.Status = serverstatus.AddServer
-			} else if mode, exist := resourceutils.GetAnnotationField(m.OBServer, oceanbaseconst.AnnotationsMode); exist && mode == oceanbaseconst.ModeStandalone {
+			if mode, exist := resourceutils.GetAnnotationField(m.OBServer, oceanbaseconst.AnnotationsMode); exist && mode == oceanbaseconst.ModeStandalone {
 				if pod.Spec.Containers[0].Resources.Limits.Cpu().Cmp(m.OBServer.Spec.OBServerTemplate.Resource.Cpu) != 0 ||
 					pod.Spec.Containers[0].Resources.Limits.Memory().Cmp(m.OBServer.Spec.OBServerTemplate.Resource.Memory) != 0 {
 					m.OBServer.Status.Status = serverstatus.ScaleUp
@@ -228,8 +223,6 @@ func (m *OBServerManager) GetTaskFlow() (*tasktypes.TaskFlow, error) {
 		taskFlow = genRecoverOBServerFlow(m)
 	case serverstatus.Annotate:
 		taskFlow = genAnnotateOBServerPodFlow(m)
-	case serverstatus.AddServer:
-		taskFlow = genAddServerInOBFlow(m)
 	case serverstatus.ScaleUp:
 		taskFlow = genScaleUpOBServerFlow(m)
 	case serverstatus.ExpandPVC:


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
optimize observer recover logic.

Related to #325 


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
move add server task into recover task flow
remove the logic requiring to connect to oceanbase cluster in observer_manager when updating observer's status


![image](https://github.com/oceanbase/ob-operator/assets/85611200/2f86374d-256e-4267-94af-4f7e0c3ea8a9)

