### PR TITLE
Fixed missing path parameters in obproxy api docs

### DIFF
--- a/internal/dashboard/generated/swagger/docs.go
+++ b/internal/dashboard/generated/swagger/docs.go
@@ -2998,6 +2998,22 @@ const docTemplate = `{
                 ],
                 "summary": "Get OBProxy",
                 "operationId": "GetOBProxy",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "namespace of obproxy deployment",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "name of obproxy deployment",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -3055,6 +3071,22 @@ const docTemplate = `{
                 ],
                 "summary": "Delete OBProxy",
                 "operationId": "DeleteOBProxy",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "namespace of obproxy deployment",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "name of obproxy deployment",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -3121,6 +3153,20 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/obproxy.PatchOBProxyParam"
                         }
+                    },
+                    {
+                        "type": "string",
+                        "description": "namespace of obproxy deployment",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "name of obproxy deployment",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {

--- a/internal/dashboard/generated/swagger/swagger.json
+++ b/internal/dashboard/generated/swagger/swagger.json
@@ -2991,6 +2991,22 @@
                 ],
                 "summary": "Get OBProxy",
                 "operationId": "GetOBProxy",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "namespace of obproxy deployment",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "name of obproxy deployment",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -3048,6 +3064,22 @@
                 ],
                 "summary": "Delete OBProxy",
                 "operationId": "DeleteOBProxy",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "namespace of obproxy deployment",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "name of obproxy deployment",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -3114,6 +3146,20 @@
                         "schema": {
                             "$ref": "#/definitions/obproxy.PatchOBProxyParam"
                         }
+                    },
+                    {
+                        "type": "string",
+                        "description": "namespace of obproxy deployment",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "name of obproxy deployment",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {

--- a/internal/dashboard/generated/swagger/swagger.yaml
+++ b/internal/dashboard/generated/swagger/swagger.yaml
@@ -4086,6 +4086,17 @@ paths:
       - application/json
       description: Delete OBProxy by namespace and name
       operationId: DeleteOBProxy
+      parameters:
+      - description: namespace of obproxy deployment
+        in: path
+        name: namespace
+        required: true
+        type: string
+      - description: name of obproxy deployment
+        in: path
+        name: name
+        required: true
+        type: string
       produces:
       - application/json
       responses:
@@ -4120,6 +4131,17 @@ paths:
       - application/json
       description: Get OBProxy by namespace and name
       operationId: GetOBProxy
+      parameters:
+      - description: namespace of obproxy deployment
+        in: path
+        name: namespace
+        required: true
+        type: string
+      - description: name of obproxy deployment
+        in: path
+        name: name
+        required: true
+        type: string
       produces:
       - application/json
       responses:
@@ -4161,6 +4183,16 @@ paths:
         required: true
         schema:
           $ref: '#/definitions/obproxy.PatchOBProxyParam'
+      - description: namespace of obproxy deployment
+        in: path
+        name: namespace
+        required: true
+        type: string
+      - description: name of obproxy deployment
+        in: path
+        name: name
+        required: true
+        type: string
       produces:
       - application/json
       responses:

--- a/internal/dashboard/handler/obproxy_handler.go
+++ b/internal/dashboard/handler/obproxy_handler.go
@@ -67,6 +67,8 @@ func CreateOBProxy(c *gin.Context) (*obproxy.OBProxy, error) {
 // @Tags OBProxy
 // @Accept application/json
 // @Produce application/json
+// @Param namespace path string true "namespace of obproxy deployment"
+// @Param name path string true "name of obproxy deployment"
 // @Success 200 object response.APIResponse{data=obproxy.OBProxy}
 // @Failure 400 object response.APIResponse
 // @Failure 401 object response.APIResponse
@@ -89,6 +91,8 @@ func GetOBProxy(c *gin.Context) (*obproxy.OBProxy, error) {
 // @Accept application/json
 // @Produce application/json
 // @Param body body obproxy.PatchOBProxyParam true "Request body for patching obproxy"
+// @Param namespace path string true "namespace of obproxy deployment"
+// @Param name path string true "name of obproxy deployment"
 // @Success 200 object response.APIResponse{data=obproxy.OBProxy}
 // @Failure 400 object response.APIResponse
 // @Failure 401 object response.APIResponse
@@ -115,6 +119,8 @@ func PatchOBProxy(c *gin.Context) (*obproxy.OBProxy, error) {
 // @Tags OBProxy
 // @Accept application/json
 // @Produce application/json
+// @Param namespace path string true "namespace of obproxy deployment"
+// @Param name path string true "name of obproxy deployment"
 // @Success 200 object response.APIResponse{data=obproxy.OBProxy}
 // @Failure 400 object response.APIResponse
 // @Failure 401 object response.APIResponse


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

The missing params in api docs would lead to failure when generating typescript sdk in front-end development.