### PR TITLE
use python3 to execute upgrade scripts

### DIFF
--- a/build/Dockerfile.observer
+++ b/build/Dockerfile.observer
@@ -10,8 +10,9 @@ ARG TARGETPLATFORM
 WORKDIR /home/admin/oceanbase
 RUN mkdir -p /home/admin/oceanbase/bin
 COPY --from=builder /workspace/oceanbase-helper /home/admin/oceanbase/bin
-RUN yum -y install python27
-RUN pip2 install mysql-connector -i http://mirrors.aliyun.com/pypi/simple/ --trusted-host mirrors.aliyun.com
+RUN yum -y install python3
+RUN ln -sf /usr/bin/python3 /usr/bin/python
+RUN pip3 install mysql-connector-python==8.0.28 -i http://mirrors.aliyun.com/pypi/simple/ --trusted-host mirrors.aliyun.com
 # support docker platform linux/amd64 and linux/arm64, mapping platform to x86_64 or aarch64
 RUN if [[ ${TARGETPLATFORM} == 'linux/amd64' ]] ; then yum install -y http://mirrors.aliyun.com/oceanbase/community/stable/el/8/x86_64/oceanbase-ce-libs-${VERSION}.el8.x86_64.rpm ; else yum install -y http://mirrors.aliyun.com/oceanbase/community/stable/el/8/aarch64/oceanbase-ce-libs-${VERSION}.el8.aarch64.rpm ; fi
 RUN if [[ ${TARGETPLATFORM} == 'linux/amd64' ]] ; then yum install -y http://mirrors.aliyun.com/oceanbase/community/stable/el/8/x86_64/oceanbase-ce-${VERSION}.el8.x86_64.rpm ; else yum install -y http://mirrors.aliyun.com/oceanbase/community/stable/el/8/aarch64/oceanbase-ce-${VERSION}.el8.aarch64.rpm ; fi

--- a/build/Dockerfile.operator
+++ b/build/Dockerfile.operator
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20.4 as builder
+FROM golang:1.22 as builder
 
 ARG GOPROXY
 ARG GOSUMDB
@@ -8,7 +8,7 @@ ARG RACE
 WORKDIR /workspace
 # copy everything
 COPY . .
-RUN GO11MODULE=ON CGO_ENABLED=1 GOOS=linux go build ${RACE} -o manager cmd/operator/main.go
+RUN GO11MODULE=ON CGO_ENABLED=0 GOOS=linux go build ${RACE} -o manager cmd/operator/main.go
 
 # start build docker image
 FROM openanolis/anolisos:8.8

--- a/internal/resource/utils/jobs.go
+++ b/internal/resource/utils/jobs.go
@@ -177,7 +177,7 @@ func ExecuteUpgradeScript(ctx context.Context, c client.Client, logger *logr.Log
 	container := corev1.Container{
 		Name:    "script-runner",
 		Image:   obcluster.Spec.OBServerTemplate.Image,
-		Command: []string{"bash", "-c", fmt.Sprintf("python2 %s -h%s -P%d -uroot -p'%s' %s", filepath, rootserver.Ip, rootserver.SqlPort, password, extraOpt)},
+		Command: []string{"bash", "-c", fmt.Sprintf("if [[ `command -v python2` ]]; then ln -sf /usr/bin/python2 /usr/bin/python; fi && python %s -h%s -P%d -uroot -p'%s' %s", filepath, rootserver.Ip, rootserver.SqlPort, password, extraOpt)},
 	}
 	job := batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
use python3 to execute upgrade scripts


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
modify docker image of observer, install python3 as python executor
check python executor and use /usr/bin/python to execute upgrade scripts
