### PR TITLE
Bumped go version in Dockerfiles

### DIFF
--- a/build/Dockerfile.dashboard
+++ b/build/Dockerfile.dashboard
@@ -5,7 +5,7 @@ ENV NODE_OPTIONS=--max_old_space_size=5120
 RUN yarn
 RUN yarn build
 
-FROM golang:1.20.4 as builder-be
+FROM golang:1.22 as builder-be
 ARG GOPROXY=https://goproxy.io,direct
 ARG GOSUMDB=sum.golang.org
 ARG COMMIT_HASH=unknown

--- a/build/Dockerfile.observer
+++ b/build/Dockerfile.observer
@@ -1,4 +1,4 @@
-FROM golang:1.20.4 as builder
+FROM golang:1.22 as builder
 ARG GOPROXY=https://goproxy.io,direct
 WORKDIR /workspace
 COPY . .

--- a/make/dashboard.mk
+++ b/make/dashboard.mk
@@ -11,7 +11,7 @@ BUILD_TIMESTAMP ?= $(shell date '+%Y%m%d%H%M%S')
 INJECT_PACKAGE=github.com/oceanbase/ob-operator/internal/dashboard/handler
 
 BUILD_FLAG      := -p $(PROCESSOR) -ldflags="-X '$(INJECT_PACKAGE).Version=$(DASHBOARD_VERSION)' -X '$(INJECT_PACKAGE).CommitHash=$(COMMIT_HASH)' -X '$(INJECT_PACKAGE).BuildTime=$(BUILD_TIMESTAMP)'"
-GOBUILD         := go build $(BUILD_FLAG)
+GOBUILD         := CGO_ENABLED=0 go build $(BUILD_FLAG)
 GOBUILDCOVERAGE := go test -covermode=count -coverpkg="../..." -c .
 GOCOVERAGE_FILE := tests/coverage.out
 GOCOVERAGE_REPORT := tests/coverage-report


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

Without `CGO_ENABLED=0`, the new dashboard executable throws `libc not found` error
