### PR TITLE
Fixed axios base path that causes 404

### DIFF
--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -16,7 +16,7 @@ globalAxios.interceptors.response.use((res) => {
 });
 
 const config = new Configuration({
-  basePath: process.env.NODE_ENV === 'development' ? location.origin : '/',
+  basePath: location.origin,
   apiKey: () => document.cookie,
   baseOptions: {
     withCredentials: true,


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

Single slash `/` in axios basePath causes wrong accessing for api endpoint.

<img width="736" alt="image" src="https://github.com/oceanbase/ob-operator/assets/26134111/8c926dbe-da71-4bf4-8b94-fcaf87f2612a">

