### PR TITLE
use second unit for duration in alarm rule

### DIFF
--- a/internal/dashboard/model/alarm/rule/rule.go
+++ b/internal/dashboard/model/alarm/rule/rule.go
@@ -91,7 +91,7 @@ func (r *Rule) ToPromRule() *rulefmt.Rule {
 	promRule := &rulefmt.Rule{
 		Alert:       r.Name,
 		Expr:        r.Query,
-		For:         prommodel.Duration(r.Duration * int(time.Minute)),
+		For:         prommodel.Duration(r.Duration * int(time.Second)),
 		Labels:      bizcommon.KVsToMap(labels),
 		Annotations: annotations,
 	}
@@ -133,7 +133,7 @@ func NewRuleResponse(promRule *promv1.AlertingRule) *RuleResponse {
 		InstanceType: instanceType,
 		Type:         ruleType,
 		Query:        promRule.Query,
-		Duration:     int(promRule.Duration / 60),
+		Duration:     int(promRule.Duration),
 		Labels:       labels,
 		Severity:     severity,
 		Summary:      summary,


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
use second unit for duration in alarm rule


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
