### PR TITLE
fix gitignore not working for go vendor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ tags
 bin
 
 # lib & package
-.vendor/
+vendor/
 .glide/
 
 # Test binary


### PR DESCRIPTION
## Summary
fix gitignore not working for go vendor

when i run `go mod vendor` in package,there are too many files in git stage



## Solution Description
<!-- Please clearly and concisely describe your solution. -->
