### PR TITLE
Solve the problem of selecting masked objects

### DIFF
--- a/ui/src/pages/Alert/Shield/ShieldObjInput.tsx
+++ b/ui/src/pages/Alert/Shield/ShieldObjInput.tsx
@@ -82,6 +82,9 @@ export default function ShieldObjInput({
           title: cluster.clusterName,
           options: cluster.tenants?.map((item) => ({
             value: item,
+            disabled: selectedTenants?.length
+              ? !cluster.tenants?.includes(selectedTenants[0])
+              : false,
             label: item,
           })),
         }));
@@ -113,6 +116,9 @@ export default function ShieldObjInput({
           title: cluster.clusterName,
           options: cluster.servers?.map((item) => ({
             value: item,
+            disabled: selectedServers?.length
+              ? !cluster.servers?.includes(selectedServers[0])
+              : false,
             label: item,
           })),
         }));
@@ -144,6 +150,7 @@ export default function ShieldObjInput({
     useUpdateEffect(() => {
       if (!selectedCluster?.length) {
         form.setFieldValue(nextFormName, undefined);
+        form.setFieldValue(clusterFormName, undefined);
       }
     }, [selectedCluster]);
     return (
@@ -178,7 +185,7 @@ export default function ShieldObjInput({
           </Form.Item>
         </Col>
         <Col span={16}>
-          <Form.Item noStyle dependencies={[clusterFormName]}>
+          <Form.Item noStyle dependencies={[clusterFormName, nextFormName]}>
             {({ getFieldValue }) => {
               const cluster = getFieldValue(clusterFormName);
               return (

--- a/ui/src/pages/Alert/helper.ts
+++ b/ui/src/pages/Alert/helper.ts
@@ -121,6 +121,10 @@ export const formatShieldSubmitData = (
     const temp = selectList.find(
       (item) => item?.clusterName === cloneFormData.instances.obcluster[0],
     ) as Alert.ServersList & Alert.TenantsList;
+    
+    // Manually add the default tenant sys
+    selectInstance?.includes('allTenants') && temp.tenants?.push('sys');
+
     cloneFormData.instances[cloneFormData.instances.type] =
       temp?.tenants || temp?.servers || [];
     selectInstance = temp?.tenants || temp?.servers || [];

--- a/ui/src/pages/Alert/helper.ts
+++ b/ui/src/pages/Alert/helper.ts
@@ -35,7 +35,7 @@ export const getSelectList = (
       return clusterList
         .filter((cluster) => {
           const temp = tenantList?.filter((tenant) =>
-            selectedTenants.includes(tenant.name),
+            selectedTenants.includes(tenant.tenantName),
           );
           return temp?.some(
             (tenant) => tenant.clusterResourceName === cluster.name,

--- a/ui/src/pages/OBProxy/Detail/Overview/ConfigDrawer.tsx
+++ b/ui/src/pages/OBProxy/Detail/Overview/ConfigDrawer.tsx
@@ -9,7 +9,7 @@ import { MIRROR_OBPROXY } from '@/constants/doc';
 import { OBProxy } from '@/type/obproxy';
 import { intl } from '@/utils/intl';
 import { MinusCircleOutlined, PlusOutlined } from '@ant-design/icons';
-import { useRequest } from 'ahooks';
+import { useDebounceFn, useRequest } from 'ahooks';
 import type { DrawerProps } from 'antd';
 import {
   Button,
@@ -77,6 +77,7 @@ export default function ConfigDrawer({
       onClose();
     }
   };
+  const { run: debounceSubmit } = useDebounceFn(submit, { wait: 300 });
   const titleStyle = { fontSize: 14, fontWeight: 600 };
 
   const labelChange = (label: string, name: number) => {
@@ -108,7 +109,7 @@ export default function ConfigDrawer({
       <Form
         initialValues={props}
         form={form}
-        onFinish={submit}
+        onFinish={debounceSubmit}
         layout="vertical"
       >
         <p style={titleStyle}>


### PR DESCRIPTION
## Summary

1. Manually add the default tenant sys.
![image](https://github.com/oceanbase/ob-operator/assets/62841398/f26129c5-d336-4396-816b-cf0f475219d5)

3. Add restrictions: Only allow tenants or observers in the current cluster to be selected.
![image](https://github.com/oceanbase/ob-operator/assets/62841398/3eec331a-a2c0-4a04-b2ff-338a309956a5)

5. Get the tenant name from the property `tenantName` instead of `name`.