### PR TITLE
fix: bump controller-gen to v0.15.0

### DIFF
--- a/make/deps.mk
+++ b/make/deps.mk
@@ -11,7 +11,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.0.0
-CONTROLLER_TOOLS_VERSION ?= v0.13.0 # v0.11.3 can not support webhook manifests' generation, update to v0.13.0
+CONTROLLER_TOOLS_VERSION ?= v0.15.0 # v0.13.0 will cause Panic, update to v0.15.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Controller-gen v0.13.0 cause Panic with go linux/darwin64 and go linux/amd64.
Details in issue: #483 

## Solution Description
<!-- Please clearly and concisely describe your solution. -->
bump controller-gen to v0.15.0 (latest version by now)
