### PR TITLE
Add support for custom schedulerName in observer pod configuration

### DIFF
--- a/api/types/podfields.go
+++ b/api/types/podfields.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 OceanBase
+Copyright (c) 2024 OceanBase
 ob-operator is licensed under Mulan PSL v2.
 You can use this software according to the terms and conditions of the Mulan PSL v2.
 You may obtain a copy of Mulan PSL v2 at:
@@ -12,9 +12,6 @@ See the Mulan PSL v2 for more details.
 
 package types
 
-type OBServerTemplate struct {
-	Image     string                `json:"image"`
-	Resource  *ResourceSpec         `json:"resource"`
-	Storage   *OceanbaseStorageSpec `json:"storage"`
-	PodFields *PodFieldsSpec        `json:"podFields,omitempty"`
+type PodFieldsSpec struct {
+	SchedulerName *string `json:"schedulerName,omitempty"`
 }

--- a/config/crd/bases/oceanbase.oceanbase.com_obclusteroperations.yaml
+++ b/config/crd/bases/oceanbase.oceanbase.com_obclusteroperations.yaml
@@ -4610,6 +4610,11 @@ spec:
                         properties:
                           image:
                             type: string
+                          podFields:
+                            properties:
+                              schedulerName:
+                                type: string
+                            type: object
                           resource:
                             properties:
                               cpu:

--- a/config/crd/bases/oceanbase.oceanbase.com_obclusters.yaml
+++ b/config/crd/bases/oceanbase.oceanbase.com_obclusters.yaml
@@ -1775,6 +1775,11 @@ spec:
                 properties:
                   image:
                     type: string
+                  podFields:
+                    properties:
+                      schedulerName:
+                        type: string
+                    type: object
                   resource:
                     properties:
                       cpu:

--- a/config/crd/bases/oceanbase.oceanbase.com_observers.yaml
+++ b/config/crd/bases/oceanbase.oceanbase.com_observers.yaml
@@ -2678,6 +2678,11 @@ spec:
                 properties:
                   image:
                     type: string
+                  podFields:
+                    properties:
+                      schedulerName:
+                        type: string
+                    type: object
                   resource:
                     properties:
                       cpu:

--- a/config/crd/bases/oceanbase.oceanbase.com_obzones.yaml
+++ b/config/crd/bases/oceanbase.oceanbase.com_obzones.yaml
@@ -1781,6 +1781,11 @@ spec:
                 properties:
                   image:
                     type: string
+                  podFields:
+                    properties:
+                      schedulerName:
+                        type: string
+                    type: object
                   resource:
                     properties:
                       cpu:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -4633,6 +4633,11 @@ spec:
                         properties:
                           image:
                             type: string
+                          podFields:
+                            properties:
+                              schedulerName:
+                                type: string
+                            type: object
                           resource:
                             properties:
                               cpu:
@@ -7626,6 +7631,11 @@ spec:
                 properties:
                   image:
                     type: string
+                  podFields:
+                    properties:
+                      schedulerName:
+                        type: string
+                    type: object
                   resource:
                     properties:
                       cpu:
@@ -11695,6 +11705,11 @@ spec:
                 properties:
                   image:
                     type: string
+                  podFields:
+                    properties:
+                      schedulerName:
+                        type: string
+                    type: object
                   resource:
                     properties:
                       cpu:
@@ -17177,6 +17192,11 @@ spec:
                 properties:
                   image:
                     type: string
+                  podFields:
+                    properties:
+                      schedulerName:
+                        type: string
+                    type: object
                   resource:
                     properties:
                       cpu:

--- a/internal/resource/observer/utils.go
+++ b/internal/resource/observer/utils.go
@@ -285,6 +285,7 @@ func (m *OBServerManager) createOBPodSpec(obcluster *v1alpha1.OBCluster) corev1.
 		Affinity:           m.OBServer.Spec.Affinity,
 		Tolerations:        m.OBServer.Spec.Tolerations,
 		ServiceAccountName: m.OBServer.Spec.ServiceAccount,
+		SchedulerName:      resourceutils.GetSchedulerName(m.OBServer.Spec.OBServerTemplate.PodFields),
 	}
 	return podSpec
 }

--- a/internal/resource/obtenant/obtenant_task.go
+++ b/internal/resource/obtenant/obtenant_task.go
@@ -523,7 +523,11 @@ func OptimizeTenantByScenario(m *OBTenantManager) tasktypes.TaskError {
 	}
 	m.Logger.Info("Start to optimize tenant parameter and variable")
 	jobName := fmt.Sprintf("optimize-tenant-%s-%s", m.OBTenant.Name, rand.String(6))
-	output, code, _ := resourceutils.RunJob(m.Ctx, m.Client, m.Logger, m.OBTenant.Namespace, jobName, obcluster.Spec.OBServerTemplate.Image, fmt.Sprintf("bin/oceanbase-helper optimize tenant %s", m.OBTenant.Spec.Scenario))
+	output, code, _ := resourceutils.RunJob(m.Ctx, m.Client, m.Logger, m.OBTenant.Namespace,
+		jobName,
+		obcluster.Spec.OBServerTemplate.Image,
+		obcluster.Spec.OBServerTemplate.PodFields,
+		fmt.Sprintf("bin/oceanbase-helper optimize tenant %s", m.OBTenant.Spec.Scenario))
 	if code == int32(cmdconst.ExitCodeOK) || code == int32(cmdconst.ExitCodeIgnorableErr) {
 		optimizeConfig := &helpermodel.OptimizationResponse{}
 		err := json.Unmarshal([]byte(output), optimizeConfig)

--- a/internal/resource/utils/jobs.go
+++ b/internal/resource/utils/jobs.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	apitypes "github.com/oceanbase/ob-operator/api/types"
 	"github.com/oceanbase/ob-operator/api/v1alpha1"
 	obcfg "github.com/oceanbase/ob-operator/internal/config/operator"
 	cmdconst "github.com/oceanbase/ob-operator/internal/const/cmd"
@@ -50,7 +51,9 @@ type JobContainerVolumes struct {
 	Volumes      []corev1.Volume
 }
 
-func RunJob(ctx context.Context, c client.Client, logger *logr.Logger, namespace string, jobName string, image string, cmd string, volumeConfigs ...JobContainerVolumes) (output string, exitCode int32, err error) {
+func RunJob(ctx context.Context, c client.Client, logger *logr.Logger, namespace string,
+	jobName string, image string, podFields *apitypes.PodFieldsSpec,
+	cmd string, volumeConfigs ...JobContainerVolumes) (output string, exitCode int32, err error) {
 	fullJobName := fmt.Sprintf("%s-%s", jobName, rand.String(6))
 	var backoffLimit int32
 	var ttl int32 = 300
@@ -78,6 +81,7 @@ func RunJob(ctx context.Context, c client.Client, logger *logr.Logger, namespace
 					Containers:    []corev1.Container{container},
 					RestartPolicy: corev1.RestartPolicyNever,
 					Volumes:       volumes,
+					SchedulerName: GetSchedulerName(podFields),
 				},
 			},
 			BackoffLimit:            &backoffLimit,

--- a/internal/resource/utils/podfields.go
+++ b/internal/resource/utils/podfields.go
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2024 OceanBase
+ob-operator is licensed under Mulan PSL v2.
+You can use this software according to the terms and conditions of the Mulan PSL v2.
+You may obtain a copy of Mulan PSL v2 at:
+         http://license.coscl.org.cn/MulanPSL2
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+See the Mulan PSL v2 for more details.
+*/
+
+package utils
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/oceanbase/ob-operator/api/types"
+)
+
+// GetSchedulerName returns the scheduler name from the given PodFields.
+// If PodFields or SchedulerName is nil, it returns the default scheduler name.
+func GetSchedulerName(podFields *types.PodFieldsSpec) string {
+	if podFields == nil || podFields.SchedulerName == nil {
+		return corev1.DefaultSchedulerName // return Kubernetes's default scheduler name
+	}
+	return *podFields.SchedulerName
+}


### PR DESCRIPTION
**Description**:

This MR introduces a new feature that allows users to specify a custom scheduler for the observer pods in the ob cluster. The changes include:

- podFields support: A new field podFields has been added to the observer configuration in the CRD, allowing users to define specific configurations related to the pod.
- Custom schedulerName: Under podFields, users can now specify the schedulerName, enabling them to use a custom Kubernetes scheduler instead of the default one.

**Changes include:**

- Updated CRD schema to include podFields and schedulerName.
- Modified the controller logic to apply the schedulerName to the observer pods if specified.
- Ensured backward compatibility so that if schedulerName is not provided, the default scheduler is used.

**Usage Example:**
Here’s an example of how users can define the schedulerName for observer pods using the new podFields field:

```yaml
apiVersion: oceanbase.oceanbase.com/v1alpha1
kind: OBCluster
metadata:
  name: test
  namespace: oceanbase
spec:
  observer:
    image: oceanbase/oceanbase-cloud-native:4.2.3.1-101000032024061316
    podFields:
      schedulerName: custom-scheduler
    resource:
      cpu: 2
      memory: 8Gi
    storage:
      dataStorage:
        ...
      redoLogStorage:
        ..
      logStorage:
        ..
...
```
