### PR TITLE
fix:password input&statistics&createdRoles

### DIFF
--- a/ui/src/components/customModal/HandleAccountModal.tsx
+++ b/ui/src/components/customModal/HandleAccountModal.tsx
@@ -3,6 +3,7 @@ import type { AcAccount, AcCreateAccountParam } from '@/api/generated';
 import { encryptText, usePublicKey } from '@/hook/usePublicKey';
 import { Type } from '@/pages/Access/type';
 import { intl } from '@/utils/intl';
+import { useModel } from '@umijs/max';
 import { useRequest } from 'ahooks';
 import { Form, Input, Select, message } from 'antd';
 import { omit } from 'lodash';
@@ -25,6 +26,7 @@ export default function HandleAccountModal({
   type,
 }: HandleRoleModalProps) {
   const [form] = Form.useForm();
+  const { refresh } = useModel('@@initialState');
   const publicKey = usePublicKey();
   const handleSubmit = async () => {
     try {
@@ -55,6 +57,7 @@ export default function HandleAccountModal({
             omit(formData, ['confirmPassword', 'username', 'password']),
           );
     if (res.successful) {
+      if (type === Type.EDIT) await refresh();
       message.success(
         intl.formatMessage({
           id: 'src.components.customModal.8EA35AF0',

--- a/ui/src/components/customModal/HandleRoleModal.tsx
+++ b/ui/src/components/customModal/HandleRoleModal.tsx
@@ -14,7 +14,7 @@ interface HandleRoleModalProps {
   setVisible: (visible: boolean) => void;
   successCallback?: () => void;
   editValue?: AcRole;
-  existingRole?: string[];
+  createdRoles?: string[];
   type: Type;
 }
 
@@ -147,7 +147,7 @@ export default function HandleRoleModal({
   setVisible,
   successCallback,
   editValue,
-  existingRole,
+  createdRoles,
   type,
 }: HandleRoleModalProps) {
   const [form] = Form.useForm();
@@ -170,7 +170,7 @@ export default function HandleRoleModal({
     }
   });
   const onFinish = async (formData: AcCreateRoleParam) => {
-    if (type === Type.CREATE && existingRole?.includes(formData.name)) {
+    if (type === Type.CREATE && createdRoles?.includes(formData.name)) {
       message.warning(
         intl.formatMessage({
           id: 'src.components.customModal.08DC5F92',

--- a/ui/src/components/customModal/ResetPwdModal.tsx
+++ b/ui/src/components/customModal/ResetPwdModal.tsx
@@ -87,7 +87,7 @@ export default function ResetPwdModal({
             })}
             name={'oldPassword'}
           >
-            <Input
+            <Input.Password
               type="password"
               placeholder={intl.formatMessage({
                 id: 'src.components.customModal.E97DEF21',
@@ -129,7 +129,7 @@ export default function ResetPwdModal({
           })}
           name={'password'}
         >
-          <Input
+          <Input.Password
             type="password"
             placeholder={intl.formatMessage({
               id: 'src.components.customModal.8BE441F0',
@@ -169,7 +169,7 @@ export default function ResetPwdModal({
           })}
           name={'confirmPassword'}
         >
-          <Input
+          <Input.Password
             type="password"
             placeholder={intl.formatMessage({
               id: 'src.components.customModal.69F2300D',

--- a/ui/src/pages/Access/index.tsx
+++ b/ui/src/pages/Access/index.tsx
@@ -40,6 +40,10 @@ export default function Access() {
     );
   }, [allAccounts]);
 
+  const createdRoles = useMemo(() => {
+    return allRoles?.map((item) => item.name) || [];
+  }, [allRolesRes]);
+
   const items: TabsProps['items'] = [
     {
       key: ActiveKey.ACCOUNTS,
@@ -61,7 +65,7 @@ export default function Access() {
         <Roles
           allRoles={allRoles}
           refreshRoles={refreshRoles}
-          existingRoles={existingRoles}
+          existingRoles={existingRoles} // A role in use cannot be deleted
         />
       ),
     },
@@ -113,8 +117,8 @@ export default function Access() {
       <HandleRoleModal
         visible={modalVisible}
         setVisible={setModalVisible}
-        existingRole={existingRoles}
         type={Type.CREATE}
+        createdRoles={createdRoles} // Duplicate roles cannot be created
         successCallback={refreshRoles}
       />
     </PageContainer>

--- a/ui/src/pages/Login/index.tsx
+++ b/ui/src/pages/Login/index.tsx
@@ -59,7 +59,7 @@ const Login: React.FC = () => {
           name="password"
           rules={[{ required: true, message: 'Please input your Password!' }]}
         >
-          <Input
+          <Input.Password
             prefix={<LockOutlined />}
             type="password"
             placeholder="Password"

--- a/ui/src/pages/Overview/index.tsx
+++ b/ui/src/pages/Overview/index.tsx
@@ -19,9 +19,11 @@ const OverviewPage: React.FC = () => {
       }}
     >
       <Row justify="start" gutter={[16, 16]}>
+        {access.obclusterread || access.obclusterwrite ? (
+          <OverviewStatus />
+        ) : null}
         {access.systemread || access.systemwrite ? (
           <>
-            <OverviewStatus />
             <Col span={24}>
               <EventsTable />
             </Col>

--- a/ui/src/pages/ResetPwd/index.tsx
+++ b/ui/src/pages/ResetPwd/index.tsx
@@ -61,7 +61,7 @@ export default function ResetPwd() {
             },
           ]}
         >
-          <Input
+          <Input.Password
             type="password"
             placeholder={intl.formatMessage({
               id: 'src.pages.ResetPwd.EB8B735A',
@@ -96,7 +96,7 @@ export default function ResetPwd() {
             }),
           ]}
         >
-          <Input
+          <Input.Password
             type="password"
             placeholder={intl.formatMessage({
               id: 'src.pages.ResetPwd.0D23DF17',


### PR DESCRIPTION
## Summary

1. Using `Input.Password` replace `Input`.
2. Duplicate roles cannot be created.
3. Refresh access after editing an account.
