### PR TITLE
Adjusted permission required by several api

### DIFF
--- a/internal/dashboard/router/v1/conn_router.go
+++ b/internal/dashboard/router/v1/conn_router.go
@@ -16,11 +16,12 @@ import (
 	"github.com/gin-gonic/gin"
 
 	acbiz "github.com/oceanbase/ob-operator/internal/dashboard/business/ac"
+	obbiz "github.com/oceanbase/ob-operator/internal/dashboard/business/oceanbase"
 	h "github.com/oceanbase/ob-operator/internal/dashboard/handler"
 )
 
 func InitTerminalRoutes(g *gin.RouterGroup) {
 	g.PUT("/obclusters/namespace/:namespace/name/:name/terminal", h.Wrap(h.CreateOBClusterConnTerminal, acbiz.PathGuard("obcluster", ":namespace+:name", "write")))
-	g.PUT("/obtenants/:namespace/:name/terminal", h.Wrap(h.CreateOBTenantConnTerminal, acbiz.PathGuard("obtenant", ":namespace+:name", "write")))
+	g.PUT("/obtenants/:namespace/:name/terminal", h.Wrap(h.CreateOBTenantConnTerminal, obbiz.TenantGuard(":namespace", ":name", "write")))
 	g.GET("/terminal/:terminalId", h.Wrap(h.ConnectDatabase))
 }

--- a/internal/dashboard/router/v1/metric_router.go
+++ b/internal/dashboard/router/v1/metric_router.go
@@ -20,6 +20,6 @@ import (
 )
 
 func InitMetricRoutes(g *gin.RouterGroup) {
-	g.GET("/metrics", h.Wrap(h.ListMetricMetas, acbiz.PathGuard("system", "*", "read")))
-	g.POST("/metrics/query", h.Wrap(h.QueryMetrics, acbiz.PathGuard("system", "*", "read")))
+	g.GET("/metrics", h.Wrap(h.ListMetricMetas, acbiz.PathGuard("obcluster", "*", "read")))
+	g.POST("/metrics/query", h.Wrap(h.QueryMetrics, acbiz.PathGuard("obcluster", "*", "read")))
 }


### PR DESCRIPTION
1. Fixed wrong configuration of api that creates connection to a tenant.
2. Modify permission required by metrics api from `system:read` to `obcluster:read`.