### PR TITLE
Join enforcers with OR and AND logic

### DIFF
--- a/internal/dashboard/business/ac/enforcers.go
+++ b/internal/dashboard/business/ac/enforcers.go
@@ -58,3 +58,26 @@ func PathGuard(domain, resource, action string) EnforceFunc {
 		return true, nil
 	}
 }
+
+func unionHelper(allPass bool, enforces ...EnforceFunc) EnforceFunc {
+	return func(c *gin.Context) (bool, error) {
+		for _, enforce := range enforces {
+			ok, err := enforce(c)
+			if err != nil {
+				return false, err
+			}
+			if ok == !allPass {
+				return !allPass, nil
+			}
+		}
+		return allPass, nil
+	}
+}
+
+func OR(enforces ...EnforceFunc) EnforceFunc {
+	return unionHelper(false, enforces...)
+}
+
+func AND(enforces ...EnforceFunc) EnforceFunc {
+	return unionHelper(true, enforces...)
+}

--- a/internal/dashboard/router/v1/metric_router.go
+++ b/internal/dashboard/router/v1/metric_router.go
@@ -19,7 +19,12 @@ import (
 	h "github.com/oceanbase/ob-operator/internal/dashboard/handler"
 )
 
+var metricGuard = acbiz.OR(
+	acbiz.PathGuard(string(acbiz.DomainOBCluster), "*", "read"),
+	acbiz.PathGuard(string(acbiz.DomainOBProxy), "*", "read"),
+)
+
 func InitMetricRoutes(g *gin.RouterGroup) {
-	g.GET("/metrics", h.Wrap(h.ListMetricMetas, acbiz.PathGuard("obcluster", "*", "read")))
-	g.POST("/metrics/query", h.Wrap(h.QueryMetrics, acbiz.PathGuard("obcluster", "*", "read")))
+	g.GET("/metrics", h.Wrap(h.ListMetricMetas, metricGuard))
+	g.POST("/metrics/query", h.Wrap(h.QueryMetrics, metricGuard))
 }


### PR DESCRIPTION
A concrete scenario is users with `obcluster:read` or `obproxy:read` permission should both be able to fetch metrics data.