### PR TITLE
Refactor(cli): move default values

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -27,8 +27,8 @@ import (
 func NewCliCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "obocli",
-		Short: "OceanBase Operator CLI",
-		Long:  "OceanBase Operator CLI tool to manage OceanBase clusters, tenants, and backups.",
+		Short: "OceanBase Operator Cli",
+		Long:  "OceanBase Operator Cli tool to manage OceanBase clusters, tenants, and backups.",
 		Run: func(cmd *cobra.Command, args []string) {
 			if cmd.Flags().Changed("version") {
 				versionCmd := version.NewCmd()

--- a/internal/cli/cluster/create.go
+++ b/internal/cli/cluster/create.go
@@ -309,8 +309,8 @@ func (o *CreateOptions) AddZoneFlags(cmd *cobra.Command) {
 func (o *CreateOptions) AddBaseFlags(cmd *cobra.Command) {
 	baseFlags := cmd.Flags()
 	baseFlags.StringVarP(&o.ClusterName, FLAG_CLUSTER_NAME, "n", "", "Cluster name, if not specified, use resource name in k8s instead")
-	baseFlags.StringVar(&o.Namespace, FLAG_NAMESPACE, "default", "The namespace of the cluster")
-	baseFlags.Int64Var(&o.ClusterId, FLAG_CLUSTER_ID, 0, "The id of the cluster")
+	baseFlags.StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of the cluster")
+	baseFlags.Int64Var(&o.ClusterId, FLAG_CLUSTER_ID, DEFAULT_ID, "The id of the cluster")
 	baseFlags.StringVarP(&o.RootPassword, FLAG_ROOTPASSWD, "p", "", "The root password of the cluster")
 	baseFlags.StringVar(&o.Mode, FLAG_MODE, "", "The mode of the cluster")
 }
@@ -318,38 +318,38 @@ func (o *CreateOptions) AddBaseFlags(cmd *cobra.Command) {
 // AddObserverFlags adds the observer-related flags to the command.
 func (o *CreateOptions) AddObserverFlags(cmd *cobra.Command) {
 	observerFlags := pflag.NewFlagSet(FLAGSET_OBSERVER, pflag.ContinueOnError)
-	observerFlags.StringVar(&o.OBServer.Image, FLAG_OBSERVER_IMAGE, "oceanbase/oceanbase-cloud-native:4.2.1.6-106000012024042515", "The image of the observer")
-	observerFlags.Int64Var(&o.OBServer.Resource.Cpu, FLAG_OBSERVER_CPU, 2, "The cpu of the observer")
-	observerFlags.Int64Var(&o.OBServer.Resource.MemoryGB, FLAG_MONITOR_MEMORY, 10, "The memory of the observer")
-	observerFlags.StringVar(&o.OBServer.Storage.Data.StorageClass, FLAG_DATA_STORAGE_CLASS, "local-path", "The storage class of the data storage")
-	observerFlags.StringVar(&o.OBServer.Storage.RedoLog.StorageClass, FLAG_REDO_LOG_STORAGE_CLASS, "local-path", "The storage class of the redo log storage")
-	observerFlags.StringVar(&o.OBServer.Storage.Log.StorageClass, FLAG_LOG_STORAGE_CLASS, "local-path", "The storage class of the log storage")
-	observerFlags.Int64Var(&o.OBServer.Storage.Data.SizeGB, FLAG_DATA_STORAGE_SIZE, 50, "The size of the data storage")
-	observerFlags.Int64Var(&o.OBServer.Storage.RedoLog.SizeGB, FLAG_REDO_LOG_STORAGE_SIZE, 50, "The size of the redo log storage")
-	observerFlags.Int64Var(&o.OBServer.Storage.Log.SizeGB, FLAG_LOG_STORAGE_SIZE, 20, "The size of the log storage")
+	observerFlags.StringVar(&o.OBServer.Image, FLAG_OBSERVER_IMAGE, DEFAULT_OBSERVER_IMAGE, "The image of the observer")
+	observerFlags.Int64Var(&o.OBServer.Resource.Cpu, FLAG_OBSERVER_CPU, DEFAULT_CPU_NUM, "The cpu of the observer")
+	observerFlags.Int64Var(&o.OBServer.Resource.MemoryGB, FLAG_MONITOR_MEMORY, DEFAULT_MONITOR_MEMORY, "The memory of the observer")
+	observerFlags.StringVar(&o.OBServer.Storage.Data.StorageClass, FLAG_DATA_STORAGE_CLASS, DEFAULT_DATA_STORAGE_CLASS, "The storage class of the data storage")
+	observerFlags.StringVar(&o.OBServer.Storage.RedoLog.StorageClass, FLAG_REDO_LOG_STORAGE_CLASS, DEFAULT_REDO_LOG_STORAGE_CLASS, "The storage class of the redo log storage")
+	observerFlags.StringVar(&o.OBServer.Storage.Log.StorageClass, FLAG_LOG_STORAGE_CLASS, DEFAULT_LOG_STORAGE_CLASS, "The storage class of the log storage")
+	observerFlags.Int64Var(&o.OBServer.Storage.Data.SizeGB, FLAG_DATA_STORAGE_SIZE, DEFAULT_DATA_STORAGE_SIZE, "The size of the data storage")
+	observerFlags.Int64Var(&o.OBServer.Storage.RedoLog.SizeGB, FLAG_REDO_LOG_STORAGE_SIZE, DEFAULT_REDO_LOG_STORAGE_SIZE, "The size of the redo log storage")
+	observerFlags.Int64Var(&o.OBServer.Storage.Log.SizeGB, FLAG_LOG_STORAGE_SIZE, DEFAULT_LOG_STORAGE_SIZE, "The size of the log storage")
 	cmd.Flags().AddFlagSet(observerFlags)
 }
 
 // AddMonitorFlags adds the monitor-related flags to the command.
 func (o *CreateOptions) AddMonitorFlags(cmd *cobra.Command) {
 	monitorFlags := pflag.NewFlagSet(FLAGSET_MONITOR, pflag.ContinueOnError)
-	monitorFlags.StringVar(&o.Monitor.Image, FLAG_MONITOR_IMAGE, "oceanbase/obagent:4.2.1-100000092023101717", "The image of the monitor")
-	monitorFlags.Int64Var(&o.Monitor.Resource.Cpu, FLAG_MONITOR_CPU, 1, "The cpu of the monitor")
-	monitorFlags.Int64Var(&o.Monitor.Resource.MemoryGB, FLAG_MONITOR_MEMORY, 1, "The memory of the monitor")
+	monitorFlags.StringVar(&o.Monitor.Image, FLAG_MONITOR_IMAGE, DEFAULT_MONITOR_IMAGE, "The image of the monitor")
+	monitorFlags.Int64Var(&o.Monitor.Resource.Cpu, FLAG_MONITOR_CPU, DEFAULT_MONITOR_CPU, "The cpu of the monitor")
+	monitorFlags.Int64Var(&o.Monitor.Resource.MemoryGB, FLAG_MONITOR_MEMORY, DEFAULT_MONITOR_MEMORY, "The memory of the monitor")
 	cmd.Flags().AddFlagSet(monitorFlags)
 }
 
 // AddBackupVolumeFlags adds the backup-volume-related flags to the command.
 func (o *CreateOptions) AddBackupVolumeFlags(cmd *cobra.Command) {
 	backupVolumeFlags := pflag.NewFlagSet(FLAGSET_BACKUP_VOLUME, pflag.ContinueOnError)
-	backupVolumeFlags.StringVar(&o.BackupVolume.Address, FLAG_BACKUP_ADDRESS, "local-path", "The storage class of the backup storage")
-	backupVolumeFlags.StringVar(&o.BackupVolume.Path, FLAG_BACKUP_PATH, "/opt/nfs", "The size of the backup storage")
+	backupVolumeFlags.StringVar(&o.BackupVolume.Address, FLAG_BACKUP_ADDRESS, DEFAULT_BACKUP_ADDRESS, "The storage class of the backup storage")
+	backupVolumeFlags.StringVar(&o.BackupVolume.Path, FLAG_BACKUP_PATH, DEFAULT_BACKUP_PATH, "The size of the backup storage")
 	cmd.Flags().AddFlagSet(backupVolumeFlags)
 }
 
 // AddParameterFlags adds the parameter-related flags, e.g. __min_full_resource_pool_memory, to the command
 func (o *CreateOptions) AddParameterFlags(cmd *cobra.Command) {
 	parameterFlags := pflag.NewFlagSet(FLAGSET_PARAMETERS, pflag.ContinueOnError)
-	parameterFlags.StringToStringVar(&o.KvParameters, FLAG_PARAMETERS, map[string]string{"__min_full_resource_pool_memory": "2147483648", "system_memory": "1G"}, "Other parameter settings in obcluster, e.g., __min_full_resource_pool_memory")
+	parameterFlags.StringToStringVar(&o.KvParameters, FLAG_PARAMETERS, map[string]string{"__min_full_resource_pool_memory": DEFAULT_MIN_FULL_RESOURCE_POOL_MEMORY, "system_memory": DEFAULT_SYSTEM_MEMORY}, "Other parameter settings in OBCluster, e.g., __min_full_resource_pool_memory")
 	cmd.Flags().AddFlagSet(parameterFlags)
 }

--- a/internal/cli/cluster/delete.go
+++ b/internal/cli/cluster/delete.go
@@ -29,5 +29,5 @@ func NewDeleteOptions() *DeleteOptions {
 
 // AddFlags add basic flags for cluster management
 func (o *DeleteOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, "default", "namespace of ob cluster")
+	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob cluster")
 }

--- a/internal/cli/cluster/enter.go
+++ b/internal/cli/cluster/enter.go
@@ -13,8 +13,9 @@ See the Mulan PSL v2 for more details.
 */
 package cluster
 
+// Flags and FlagSets for cluster management
 const (
-	// Flagsets for cluster
+	// FlagSets for cluster
 	FLAGSET_ZONE          = "zone"
 	FLAGSET_OBSERVER      = "observer"
 	FLAGSET_MONITOR       = "monitor"
@@ -53,4 +54,28 @@ const (
 
 	// Flags for parameter-related options
 	FLAG_PARAMETERS = "parameters"
+)
+
+// Default values for cluster management
+const (
+	DEFAULT_NAMESPACE              = "default"
+	DEFAULT_ID                     = 0
+	DEFAULT_CPU_NUM                = 2
+	DEFAULT_OBSERVER_IMAGE         = "oceanbase/oceanbase-cloud-native:4.2.1.6-106000012024042515"
+	DEFAULT_OBSERVER_CPU           = 2
+	DEFAULT_OBSERVER_MEMORY        = 10
+	DEFAULT_DATA_STORAGE_CLASS     = "local-path"
+	DEFAULT_REDO_LOG_STORAGE_CLASS = "local-path"
+	DEFAULT_LOG_STORAGE_CLASS      = "local-path"
+	DEFAULT_DATA_STORAGE_SIZE      = 50
+	DEFAULT_REDO_LOG_STORAGE_SIZE  = 50
+	DEFAULT_LOG_STORAGE_SIZE       = 20
+	DEFAULT_MONITOR_IMAGE          = "oceanbase/obagent:4.2.1-100000092023101717"
+	DEFAULT_MONITOR_CPU            = 1
+	DEFAULT_MONITOR_MEMORY         = 1
+	DEFAULT_BACKUP_ADDRESS         = "local-path"
+	DEFAULT_BACKUP_PATH            = "/opt/nfs"
+	// Default parameters
+	DEFAULT_MIN_FULL_RESOURCE_POOL_MEMORY = "2147483648"
+	DEFAULT_SYSTEM_MEMORY                 = "1G"
 )

--- a/internal/cli/cluster/enter.go
+++ b/internal/cli/cluster/enter.go
@@ -58,6 +58,7 @@ const (
 
 // Default values for cluster management
 const (
+	// Default values for int and string flags
 	DEFAULT_NAMESPACE              = "default"
 	DEFAULT_ID                     = 0
 	DEFAULT_CPU_NUM                = 2
@@ -75,7 +76,8 @@ const (
 	DEFAULT_MONITOR_MEMORY         = 1
 	DEFAULT_BACKUP_ADDRESS         = "local-path"
 	DEFAULT_BACKUP_PATH            = "/opt/nfs"
-	// Default parameters
+
+	// Default values for Parameter flag
 	DEFAULT_MIN_FULL_RESOURCE_POOL_MEMORY = "2147483648"
 	DEFAULT_SYSTEM_MEMORY                 = "1G"
 )

--- a/internal/cli/cluster/scale.go
+++ b/internal/cli/cluster/scale.go
@@ -140,7 +140,7 @@ func (o *ScaleOptions) Validate() error {
 			typeAdd = true
 		}
 		if typeDelete && deleteNum > maxDeleteNum {
-			return fmt.Errorf("Obcluster has %d Zones, can only delete %d zones", zoneNum, maxDeleteNum)
+			return fmt.Errorf("Ob cluster has %d Zones, can only delete %d zones", zoneNum, maxDeleteNum)
 		}
 	}
 	trueCount := 0

--- a/internal/cli/cluster/scale.go
+++ b/internal/cli/cluster/scale.go
@@ -167,6 +167,6 @@ func (o *ScaleOptions) Validate() error {
 
 // Add Flags for scale options
 func (o *ScaleOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, "default", "namespace of ob cluster")
+	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob cluster")
 	cmd.Flags().StringToStringVar(&o.Zones, FLAG_ZONES, nil, "zone of ob cluster")
 }

--- a/internal/cli/cluster/show.go
+++ b/internal/cli/cluster/show.go
@@ -29,5 +29,5 @@ func NewShowOptions() *ShowOptions {
 
 // AddFlags add basic flags for cluster management
 func (o *ShowOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, "default", "namespace of ob cluster")
+	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob cluster")
 }

--- a/internal/cli/cluster/update.go
+++ b/internal/cli/cluster/update.go
@@ -64,15 +64,15 @@ func GetUpdateOperation(o *UpdateOptions) *v1alpha1.OBClusterOperation {
 
 func (o *UpdateOptions) Validate() error {
 	updateTypeCount := 0
-	if o.Resource.Cpu != 0 || o.Resource.MemoryGB != 0 {
+	if o.CheckIfFlagChanged(FLAG_OBSERVER_CPU, FLAG_OBSERVER_MEMORY) {
 		updateTypeCount++
 		o.UpdateType = "resource"
 	}
-	if o.Storage.Data.StorageClass != "" || o.Storage.Log.StorageClass != "" || o.Storage.RedoLog.StorageClass != "" {
+	if o.CheckIfFlagChanged(FLAG_DATA_STORAGE_CLASS, FLAG_LOG_STORAGE_CLASS, FLAG_REDO_LOG_STORAGE_CLASS) {
 		updateTypeCount++
 		o.UpdateType = "modifyStorageClass"
 	}
-	if o.Storage.Data.SizeGB != 0 || o.Storage.Log.SizeGB != 0 || o.Storage.RedoLog.SizeGB != 0 {
+	if o.CheckIfFlagChanged(FLAG_DATA_STORAGE_SIZE, FLAG_LOG_STORAGE_SIZE, FLAG_REDO_LOG_STORAGE_SIZE) {
 		updateTypeCount++
 		o.UpdateType = "expandStorageSize"
 	}
@@ -129,12 +129,12 @@ func (o *UpdateOptions) Complete() error {
 // AddFlags for update options
 func (o *UpdateOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob cluster")
-	cmd.Flags().Int64Var(&o.Resource.Cpu, FLAG_OBSERVER_CPU, 0, "The cpu of the observer")
-	cmd.Flags().Int64Var(&o.Resource.MemoryGB, FLAG_MONITOR_MEMORY, 0, "The memory of the observer")
+	cmd.Flags().Int64Var(&o.Resource.Cpu, FLAG_OBSERVER_CPU, DEFAULT_OBSERVER_CPU, "The cpu of the observer")
+	cmd.Flags().Int64Var(&o.Resource.MemoryGB, FLAG_OBSERVER_MEMORY, DEFAULT_OBSERVER_MEMORY, "The memory of the observer")
 	cmd.Flags().StringVar(&o.Storage.Data.StorageClass, FLAG_DATA_STORAGE_CLASS, "", "The storage class of the data storage")
 	cmd.Flags().StringVar(&o.Storage.RedoLog.StorageClass, FLAG_REDO_LOG_STORAGE_CLASS, "", "The storage class of the redo log storage")
 	cmd.Flags().StringVar(&o.Storage.Log.StorageClass, FLAG_LOG_STORAGE_CLASS, "", "The storage class of the log storage")
-	cmd.Flags().Int64Var(&o.Storage.Data.SizeGB, FLAG_DATA_STORAGE_SIZE, 0, "The size of the data storage")
-	cmd.Flags().Int64Var(&o.Storage.RedoLog.SizeGB, FLAG_REDO_LOG_STORAGE_SIZE, 0, "The size of the redo log storage")
-	cmd.Flags().Int64Var(&o.Storage.Log.SizeGB, FLAG_LOG_STORAGE_SIZE, 0, "The size of the log storage")
+	cmd.Flags().Int64Var(&o.Storage.Data.SizeGB, FLAG_DATA_STORAGE_SIZE, DEFAULT_DATA_STORAGE_SIZE, "The size of the data storage")
+	cmd.Flags().Int64Var(&o.Storage.RedoLog.SizeGB, FLAG_REDO_LOG_STORAGE_SIZE, DEFAULT_REDO_LOG_STORAGE_SIZE, "The size of the redo log storage")
+	cmd.Flags().Int64Var(&o.Storage.Log.SizeGB, FLAG_LOG_STORAGE_SIZE, DEFAULT_LOG_STORAGE_SIZE, "The size of the log storage")
 }

--- a/internal/cli/cluster/update.go
+++ b/internal/cli/cluster/update.go
@@ -128,7 +128,7 @@ func (o *UpdateOptions) Complete() error {
 
 // AddFlags for update options
 func (o *UpdateOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, "default", "namespace of ob cluster")
+	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob cluster")
 	cmd.Flags().Int64Var(&o.Resource.Cpu, FLAG_OBSERVER_CPU, 0, "The cpu of the observer")
 	cmd.Flags().Int64Var(&o.Resource.MemoryGB, FLAG_MONITOR_MEMORY, 0, "The memory of the observer")
 	cmd.Flags().StringVar(&o.Storage.Data.StorageClass, FLAG_DATA_STORAGE_CLASS, "", "The storage class of the data storage")

--- a/internal/cli/cluster/upgrade.go
+++ b/internal/cli/cluster/upgrade.go
@@ -61,6 +61,6 @@ func (o *UpgradeOptions) Validate() error {
 
 // AddFlags for upgrade options
 func (o *UpgradeOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, "default", "namespace of ob cluster")
+	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob cluster")
 	cmd.Flags().StringVar(&o.Image, FLAG_OBSERVER_IMAGE, "", "The image of observer") // set image to null, avoid image downgrade
 }

--- a/internal/cli/cmd/cluster/cluster.go
+++ b/internal/cli/cmd/cluster/cluster.go
@@ -22,8 +22,8 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "cluster <subcommand>",
 		Aliases: []string{"c"},
-		Short:   "Command for cluster management",
-		Long:    `Command for cluster management, such as Create, UpGrade, Delete, Scale, Show.`,
+		Short:   "Command for OBCluster's management",
+		Long:    `Command for OBCluster's management, such as Create, UpGrade, Delete, Scale, Show.`,
 	}
 	cmd.AddCommand(NewCreateCmd())
 	cmd.AddCommand(NewDeleteCmd())

--- a/internal/cli/cmd/cluster/create.go
+++ b/internal/cli/cmd/cluster/create.go
@@ -28,7 +28,7 @@ func NewCreateCmd() *cobra.Command {
 	logger := cmdUtil.GetDefaultLoggerInstance()
 	cmd := &cobra.Command{
 		Use:     "create <cluster_name>",
-		Short:   "Create ob cluster",
+		Short:   "Create an ob cluster",
 		Aliases: []string{"c"},
 		Args:    cobra.ExactArgs(1),
 		PreRunE: o.Parse,
@@ -47,7 +47,7 @@ func NewCreateCmd() *cobra.Command {
 			if err != nil {
 				logger.Fatalln(err)
 			}
-			logger.Printf("Create obcluster instance: %s", o.ClusterName)
+			logger.Printf("Create OBCluster instance: %s", o.ClusterName)
 			logger.Printf("Run `echo $(kubectl get secret %s -o jsonpath='{.data.password}'|base64 --decode)` to get the secrets", obcluster.Spec.UserSecrets.Root)
 		},
 	}

--- a/internal/cli/cmd/cluster/delete.go
+++ b/internal/cli/cmd/cluster/delete.go
@@ -27,7 +27,7 @@ func NewDeleteCmd() *cobra.Command {
 	logger := cmdUtil.GetDefaultLoggerInstance()
 	cmd := &cobra.Command{
 		Use:     "delete <cluster_name>",
-		Short:   "Delete ob cluster",
+		Short:   "Delete an ob cluster",
 		Aliases: []string{"d"},
 		Args:    cobra.ExactArgs(1),
 		PreRunE: o.Parse,
@@ -36,7 +36,7 @@ func NewDeleteCmd() *cobra.Command {
 			if err != nil {
 				logger.Fatalln(err)
 			}
-			logger.Printf("Delete ob cluster %s successfully", o.Name)
+			logger.Printf("Delete OBCluster %s successfully", o.Name)
 		},
 	}
 	o.AddFlags(cmd)

--- a/internal/cli/cmd/cluster/scale.go
+++ b/internal/cli/cmd/cluster/scale.go
@@ -28,8 +28,8 @@ func NewScaleCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "scale <cluster_name>",
 		Args:    cobra.ExactArgs(1),
-		Short:   "Scale ob cluster",
-		Long:    `Scale ob cluster, support add/adjust/delete of zones.`,
+		Short:   "Scale an ob cluster",
+		Long:    `Scale an ob cluster, support add/adjust/delete of zones.`,
 		PreRunE: o.Parse,
 		Run: func(cmd *cobra.Command, args []string) {
 			obcluster, err := clients.GetOBCluster(cmd.Context(), o.Namespace, o.Name)
@@ -51,7 +51,7 @@ func NewScaleCmd() *cobra.Command {
 			if _, err = clients.CreateOBClusterOperation(cmd.Context(), op); err != nil {
 				logger.Fatalln(err)
 			}
-			logger.Printf("Create scale operation for obcluster %s successfully", op.Spec.OBCluster)
+			logger.Printf("Create scale operation for OBCluster %s successfully", op.Spec.OBCluster)
 		},
 	}
 	o.AddFlags(cmd)

--- a/internal/cli/cmd/cluster/show.go
+++ b/internal/cli/cmd/cluster/show.go
@@ -30,7 +30,7 @@ func NewShowCmd() *cobra.Command {
 	tbw, tbLog := cmdUtil.GetTableLoggerInstance()
 	cmd := &cobra.Command{
 		Use:     "show <cluster_name>",
-		Short:   "Show overview of ob cluster",
+		Short:   "Show overview of an ob cluster",
 		Args:    cobra.ExactArgs(1),
 		PreRunE: o.Parse,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/cli/cmd/cluster/update.go
+++ b/internal/cli/cmd/cluster/update.go
@@ -27,8 +27,8 @@ func NewUpdateCmd() *cobra.Command {
 	logger := cmdUtil.GetDefaultLoggerInstance()
 	cmd := &cobra.Command{
 		Use:     "update <cluster_name>",
-		Short:   "Update ob cluster",
-		Long:    "Update ob cluster, support cpu/memory/storage",
+		Short:   "Update an ob cluster",
+		Long:    "Update an ob cluster, support cpu/memory/storage",
 		Args:    cobra.ExactArgs(1),
 		Aliases: []string{"ud"},
 		PreRunE: o.Parse,
@@ -50,7 +50,7 @@ func NewUpdateCmd() *cobra.Command {
 			if _, err = clients.CreateOBClusterOperation(cmd.Context(), op); err != nil {
 				logger.Fatalln(err)
 			}
-			logger.Printf("Create update operation for obcluster %s successfully", op.Spec.OBCluster)
+			logger.Printf("Create update operation for OBCluster %s successfully", op.Spec.OBCluster)
 		},
 	}
 	o.AddFlags(cmd)

--- a/internal/cli/cmd/cluster/upgrade.go
+++ b/internal/cli/cmd/cluster/upgrade.go
@@ -27,8 +27,8 @@ func NewUpgradeCmd() *cobra.Command {
 	logger := cmdUtil.GetDefaultLoggerInstance()
 	cmd := &cobra.Command{
 		Use:     "upgrade <cluster_name>",
-		Short:   "Upgrade ob cluster",
-		Long:    "Upgrade ob cluster, please specify the new image",
+		Short:   "Upgrade an OBCluster",
+		Long:    "Upgrade an OBCluster, please specify the new image",
 		Args:    cobra.ExactArgs(1),
 		Aliases: []string{"ug"},
 		PreRunE: o.Parse,
@@ -47,7 +47,7 @@ func NewUpgradeCmd() *cobra.Command {
 			if _, err = clients.CreateOBClusterOperation(cmd.Context(), op); err != nil {
 				logger.Fatalln(err)
 			}
-			logger.Printf("Create upgrade operation for obcluster %s successfully", op.Spec.OBCluster)
+			logger.Printf("Create upgrade operation for OBCluster %s successfully", op.Spec.OBCluster)
 		},
 	}
 	o.AddFlags(cmd)

--- a/internal/cli/cmd/cluster/upgrade.go
+++ b/internal/cli/cmd/cluster/upgrade.go
@@ -27,8 +27,8 @@ func NewUpgradeCmd() *cobra.Command {
 	logger := cmdUtil.GetDefaultLoggerInstance()
 	cmd := &cobra.Command{
 		Use:     "upgrade <cluster_name>",
-		Short:   "Upgrade an OBCluster",
-		Long:    "Upgrade an OBCluster, please specify the new image",
+		Short:   "Upgrade an ob cluster",
+		Long:    "Upgrade an ob cluster, please specify the new image",
 		Args:    cobra.ExactArgs(1),
 		Aliases: []string{"ug"},
 		PreRunE: o.Parse,

--- a/internal/cli/cmd/tenant/activate.go
+++ b/internal/cli/cmd/tenant/activate.go
@@ -29,7 +29,7 @@ func NewActivateCmd() *cobra.Command {
 	logger := cmdUtil.GetDefaultLoggerInstance()
 	cmd := &cobra.Command{
 		Use:     "activate <standby_tenant_name>",
-		Short:   "Activate a standby tenant",
+		Short:   "Activate a standby ob tenant",
 		PreRunE: o.Parse,
 		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -47,13 +47,13 @@ func NewActivateCmd() *cobra.Command {
 				logger.Fatalln(err)
 			}
 			if obtenant.Status.TenantRole == apiconst.TenantRolePrimary {
-				logger.Fatalf("Obtenant %s is already PRIMARY", o.Name)
+				logger.Fatalf("OBTenant %s is already PRIMARY", o.Name)
 			}
 			op := tenant.GetActivateOperation(o)
 			if _, err = clients.CreateOBTenantOperation(cmd.Context(), op); err != nil {
 				logger.Fatalln(err)
 			}
-			logger.Printf("Create activate operation for tenant %s successfully", o.Name)
+			logger.Printf("Create activate operation for OBTenant %s successfully", o.Name)
 		},
 	}
 	o.AddFlags(cmd)

--- a/internal/cli/cmd/tenant/changepwd.go
+++ b/internal/cli/cmd/tenant/changepwd.go
@@ -54,7 +54,7 @@ func NewChangePwdCmd() *cobra.Command {
 			if _, err = clients.CreateOBTenantOperation(cmd.Context(), op); err != nil {
 				logger.Fatalln(err)
 			}
-			logger.Printf("Create changepwd operation for obtenant %s successfully", o.Name)
+			logger.Printf("Create change password operation for OBTenant %s successfully", o.Name)
 		},
 	}
 	o.AddFlags(cmd)

--- a/internal/cli/cmd/tenant/create.go
+++ b/internal/cli/cmd/tenant/create.go
@@ -26,7 +26,7 @@ func NewCreateCmd() *cobra.Command {
 	logger := cmdUtil.GetDefaultLoggerInstance()
 	cmd := &cobra.Command{
 		Use:     "create <tenant_name> --cluster=<cluster_name>",
-		Short:   "Create ob tenant",
+		Short:   "Create an ob tenant",
 		Aliases: []string{"c"},
 		PreRunE: o.Parse,
 		Args:    cobra.ExactArgs(1),
@@ -41,7 +41,7 @@ func NewCreateCmd() *cobra.Command {
 			if err != nil {
 				logger.Fatalln(err)
 			}
-			logger.Printf("Create obtenant instance: %s", o.TenantName)
+			logger.Printf("Create OBTenant instance: %s", o.TenantName)
 			logger.Printf("Run `echo $(kubectl get secret %s -o jsonpath='{.data.password}'|base64 --decode)` to get the secrets", obtenant.Spec.Credentials.Root)
 		},
 	}

--- a/internal/cli/cmd/tenant/delete.go
+++ b/internal/cli/cmd/tenant/delete.go
@@ -28,7 +28,7 @@ func NewDeleteCmd() *cobra.Command {
 	logger := cmdUtil.GetDefaultLoggerInstance()
 	cmd := &cobra.Command{
 		Use:     "delete <tenant_name>",
-		Short:   "Delete ob tenant",
+		Short:   "Delete an ob tenant",
 		Aliases: []string{"d"},
 		Args:    cobra.ExactArgs(1),
 		PreRunE: o.Parse,
@@ -40,7 +40,7 @@ func NewDeleteCmd() *cobra.Command {
 			if err != nil {
 				logger.Fatalln(err)
 			}
-			logger.Printf("Delete ob tenant %s successfully", o.Name)
+			logger.Printf("Delete OBTenant %s successfully", o.Name)
 		},
 	}
 	o.AddFlags(cmd)

--- a/internal/cli/cmd/tenant/list.go
+++ b/internal/cli/cmd/tenant/list.go
@@ -32,6 +32,7 @@ func NewListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "List ob tenants",
+		Long:    `List ob tenants.`,
 		Aliases: []string{"ls", "l"},
 		Run: func(cmd *cobra.Command, args []string) {
 			obtenantList, err := clients.ListAllOBTenants(cmd.Context(), o.Namespace, v1.ListOptions{})

--- a/internal/cli/cmd/tenant/replaylog.go
+++ b/internal/cli/cmd/tenant/replaylog.go
@@ -51,7 +51,7 @@ func NewReplayLogCmd() *cobra.Command {
 			if _, err = clients.CreateOBTenantOperation(cmd.Context(), op); err != nil {
 				logger.Fatalln(err)
 			}
-			logger.Printf("Create replay log operation of tenant %s successfully", o.Name)
+			logger.Printf("Create replay log operation of OBTenant %s successfully", o.Name)
 		},
 	}
 	o.AddFlags(cmd)

--- a/internal/cli/cmd/tenant/scale.go
+++ b/internal/cli/cmd/tenant/scale.go
@@ -28,8 +28,8 @@ func NewScaleCmd() *cobra.Command {
 	logger := cmdUtil.GetDefaultLoggerInstance()
 	cmd := &cobra.Command{
 		Use:     "scale <tenant_name>",
-		Short:   "Scale ob tenant",
-		Long:    `Scale ob tenant, support unit-number/unit config of zones.`,
+		Short:   "Scale an ob tenant",
+		Long:    `Scale an ob tenant, support unit-number/unit config of zones.`,
 		Args:    cobra.ExactArgs(1),
 		PreRunE: o.Parse,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -55,7 +55,7 @@ func NewScaleCmd() *cobra.Command {
 			if _, err = clients.CreateOBTenantOperation(cmd.Context(), op); err != nil {
 				logger.Fatalln(err)
 			}
-			logger.Printf("Create scale operation for obtenant %s successfully", o.Name)
+			logger.Printf("Create scale operation for OBTenant %s successfully", o.Name)
 		},
 	}
 	o.AddFlags(cmd)

--- a/internal/cli/cmd/tenant/switchover.go
+++ b/internal/cli/cmd/tenant/switchover.go
@@ -29,7 +29,7 @@ func NewSwitchOverCmd() *cobra.Command {
 	logger := cmdUtil.GetDefaultLoggerInstance()
 	cmd := &cobra.Command{
 		Use:     "switchover <primary_tenant_name> <standby_tenant_name>",
-		Short:   "Switchover of primary tenant and standby tenant",
+		Short:   "Switchover of primary ob tenant and standby ob tenant",
 		PreRunE: o.Parse,
 		Args:    cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/cli/cmd/tenant/tenant.go
+++ b/internal/cli/cmd/tenant/tenant.go
@@ -22,8 +22,8 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "tenant",
 		Aliases: []string{"t"},
-		Short:   "Command for tenant management",
-		Long:    `Command for tenant management, such as Create, Update, Delete, Switchover, Activate, Replaylog.`,
+		Short:   "Command for OBTenant's management",
+		Long:    `Command for OBTenant's management, such as Create, Update, Delete, Switchover, Activate, Replaylog.`,
 	}
 	cmd.AddCommand(NewCreateCmd())
 	cmd.AddCommand(NewDeleteCmd())

--- a/internal/cli/cmd/tenant/update.go
+++ b/internal/cli/cmd/tenant/update.go
@@ -56,7 +56,7 @@ func NewUpdateCmd() *cobra.Command {
 			if _, err = clients.CreateOBTenantOperation(cmd.Context(), op); err != nil {
 				logger.Fatalln(err)
 			}
-			logger.Printf("Create update operation for obtenant %s successfully", o.Name)
+			logger.Printf("Create update operation for OBTenant %s successfully", o.Name)
 		},
 	}
 	o.AddFlags(cmd)

--- a/internal/cli/cmd/tenant/update.go
+++ b/internal/cli/cmd/tenant/update.go
@@ -28,8 +28,8 @@ func NewUpdateCmd() *cobra.Command {
 	logger := cmdUtil.GetDefaultLoggerInstance()
 	cmd := &cobra.Command{
 		Use:     "update <tenant_name>",
-		Short:   "Update ob tenant",
-		Long:    "Update ob tenant, support unitNumber/connectWhiteList/priority of zones",
+		Short:   "Update an ob tenant",
+		Long:    "Update an ob tenant, support unitNumber/connectWhiteList/priority of zones",
 		Args:    cobra.ExactArgs(1),
 		Aliases: []string{"ud"},
 		PreRunE: o.Parse,

--- a/internal/cli/cmd/tenant/upgrade.go
+++ b/internal/cli/cmd/tenant/upgrade.go
@@ -28,8 +28,8 @@ func NewUpgradeCmd() *cobra.Command {
 	logger := cmdUtil.GetDefaultLoggerInstance()
 	cmd := &cobra.Command{
 		Use:     "upgrade <tenant_name>",
-		Short:   "Upgrade ob tenant to compatible version to the cluster",
-		Long:    `Upgrade ob tenant to higher version, suitable for restoring low-version backup data to a high-version cluster.`,
+		Short:   "Upgrade an ob tenant to compatible version to the ob cluster",
+		Long:    `Upgrade an ob tenant to higher version, suitable for restoring low-version backup data to a high-version ob cluster.`,
 		Args:    cobra.ExactArgs(1),
 		Aliases: []string{"ug"},
 		PreRunE: o.Parse,

--- a/internal/cli/cmd/tenant/upgrade.go
+++ b/internal/cli/cmd/tenant/upgrade.go
@@ -51,7 +51,7 @@ func NewUpgradeCmd() *cobra.Command {
 			if _, err = clients.CreateOBTenantOperation(cmd.Context(), op); err != nil {
 				logger.Fatalln(err)
 			}
-			logger.Printf("Create upgrade operation for obtenant %s successfully", o.Name)
+			logger.Printf("Create upgrade operation for OBTenant %s successfully", o.Name)
 		},
 	}
 	o.AddFlags(cmd)

--- a/internal/cli/cmd/util/validator.go
+++ b/internal/cli/cmd/util/validator.go
@@ -25,7 +25,7 @@ import (
 // CheckTenantStatus checks running status of obtenant
 func CheckTenantStatus(tenant *v1alpha1.OBTenant) error {
 	if tenant.Status.Status != tenantstatus.Running {
-		return fmt.Errorf("Obtenant status invalid, Status:%s", tenant.Status.Status)
+		return fmt.Errorf("OBTenant status invalid, Status:%s", tenant.Status.Status)
 	}
 	return nil
 }
@@ -33,7 +33,7 @@ func CheckTenantStatus(tenant *v1alpha1.OBTenant) error {
 // CheckClusterStatus checks running status of obcluster
 func CheckClusterStatus(cluster *v1alpha1.OBCluster) error {
 	if cluster.Status.Status != clusterstatus.Running {
-		return fmt.Errorf("Obcluster status invalid, Status:%s", cluster.Status.Status)
+		return fmt.Errorf("OBCluster status invalid, Status:%s", cluster.Status.Status)
 	}
 	return nil
 }
@@ -41,7 +41,7 @@ func CheckClusterStatus(cluster *v1alpha1.OBCluster) error {
 // CheckPrimaryTenant checks primary tenant for a standbytenant
 func CheckPrimaryTenant(standbytenant *v1alpha1.OBTenant) error {
 	if standbytenant.Spec.Source == nil || standbytenant.Spec.Source.Tenant == nil {
-		return fmt.Errorf("Obtenant %s has no primary tenant", standbytenant.Name)
+		return fmt.Errorf("OBTenant %s has no primary tenant", standbytenant.Name)
 	}
 	return nil
 }
@@ -49,7 +49,7 @@ func CheckPrimaryTenant(standbytenant *v1alpha1.OBTenant) error {
 // CheckTenantRole checks tenant role
 func CheckTenantRole(tenant *v1alpha1.OBTenant, role apitypes.TenantRole) error {
 	if tenant.Status.TenantRole != role {
-		return fmt.Errorf("The tenant is not %s tenant", string(role))
+		return fmt.Errorf("Tenant is not %s tenant", string(role))
 	}
 	return nil
 }

--- a/internal/cli/cmd/version/version.go
+++ b/internal/cli/cmd/version/version.go
@@ -23,9 +23,9 @@ func NewCmd() *cobra.Command {
 	logger := cmdUtil.GetDefaultLoggerInstance()
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "Print the version number of oceanbase cli",
+		Short: "Print the version number of OceanBase Cli",
 		Run: func(cmd *cobra.Command, args []string) {
-			logger.Println("Oceanbase cli Version:0.0.1")
+			logger.Println("OceanBase Cli Version: 0.0.1")
 		},
 	}
 	return cmd

--- a/internal/cli/generated/bindata/bindata.go
+++ b/internal/cli/generated/bindata/bindata.go
@@ -92,7 +92,7 @@ func internalAssetsCliTemplatesComponent_configYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "internal/assets/cli-templates/component_config.yaml", size: 219, mode: os.FileMode(420), modTime: time.Unix(1727333933, 0)}
+	info := bindataFileInfo{name: "internal/assets/cli-templates/component_config.yaml", size: 219, mode: os.FileMode(420), modTime: time.Unix(1727331319, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -156,13 +156,11 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//
-//	data/
-//	  foo.txt
-//	  img/
-//	    a.png
-//	    b.png
-//
+//     data/
+//       foo.txt
+//       img/
+//         a.png
+//         b.png
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error

--- a/internal/cli/generated/bindata/bindata.go
+++ b/internal/cli/generated/bindata/bindata.go
@@ -92,7 +92,7 @@ func internalAssetsCliTemplatesComponent_configYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "internal/assets/cli-templates/component_config.yaml", size: 219, mode: os.FileMode(420), modTime: time.Unix(1727331319, 0)}
+	info := bindataFileInfo{name: "internal/assets/cli-templates/component_config.yaml", size: 219, mode: os.FileMode(420), modTime: time.Unix(1728355358, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -156,11 +156,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error

--- a/internal/cli/tenant/activate.go
+++ b/internal/cli/tenant/activate.go
@@ -53,6 +53,6 @@ func GetActivateOperation(o *ActivateOptions) *v1alpha1.OBTenantOperation {
 
 // AddFlags add basic flags for tenant management
 func (o *ActivateOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, "default", "namespace of ob tenant")
-	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", false, "force operation")
+	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob tenant")
+	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", DEFAULT_FORCE_FLAG, "force operation")
 }

--- a/internal/cli/tenant/changepwd.go
+++ b/internal/cli/tenant/changepwd.go
@@ -87,7 +87,7 @@ func (o *ChangePwdOptions) Validate() error {
 }
 
 func (o *ChangePwdOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, "default", "namespace of ob tenant")
+	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob tenant")
 	cmd.Flags().StringVarP(&o.Password, FLAG_PASSWD, "p", "", "new password of ob tenant")
-	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", false, "force operation")
+	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", DEFAULT_FORCE_FLAG, "force operation")
 }

--- a/internal/cli/tenant/create.go
+++ b/internal/cli/tenant/create.go
@@ -413,10 +413,10 @@ func (o *CreateOptions) AddBaseFlags(cmd *cobra.Command) {
 	baseFlags := cmd.Flags()
 	baseFlags.StringVarP(&o.TenantName, FLAG_TENANT_NAME, "n", "", "Tenant name, if not specified, use name in k8s instead")
 	baseFlags.StringVar(&o.ClusterName, FLAG_CLUSTER_NAME, "", "The cluster name tenant belonged to in k8s")
-	baseFlags.StringVar(&o.Namespace, FLAG_NAMESPACE, "default", "The namespace of the tenant")
+	baseFlags.StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of the tenant")
 	baseFlags.StringVarP(&o.RootPassword, FLAG_ROOTPASSWD, "p", "", "The root password of the cluster")
-	baseFlags.StringVar(&o.Charset, FLAG_CHARSET, "utf8mb4", "The charset using in ob tenant")
-	baseFlags.StringVar(&o.ConnectWhiteList, FLAG_CONNECT_WHITE_LIST, "%", "The connect white list using in ob tenant")
+	baseFlags.StringVar(&o.Charset, FLAG_CHARSET, DEFAULT_CHARSET, "The charset using in ob tenant")
+	baseFlags.StringVar(&o.ConnectWhiteList, FLAG_CONNECT_WHITE_LIST, DEFAULT_CONNECT_WHITE_LIST, "The connect white list using in ob tenant")
 	baseFlags.StringVar(&o.From, FLAG_FROM, "", "restore from data source")
 }
 
@@ -430,27 +430,27 @@ func (o *CreateOptions) AddPoolFlags(cmd *cobra.Command) {
 // AddUnitFlags add unit-resource-related flags
 func (o *CreateOptions) AddUnitFlags(cmd *cobra.Command) {
 	unitFlags := pflag.NewFlagSet(FLAGSET_UNIT, pflag.ContinueOnError)
-	unitFlags.IntVar(&o.UnitNumber, FLAG_UNIT_NUMBER, 1, "unit number of the OBTenant")
-	unitFlags.Int64Var(&o.UnitConfig.MaxIops, FLAG_MAX_IOPS, 1024, "The max iops of unit")
-	unitFlags.Int64Var(&o.UnitConfig.MinIops, FLAG_MIN_IOPS, 1024, "The min iops of unit")
-	unitFlags.IntVar(&o.UnitConfig.IopsWeight, FLAG_IOPS_WEIGHT, 1, "The iops weight of unit")
-	unitFlags.StringVar(&o.UnitConfig.CPUCount, FLAG_CPU_COUNT, "1", "The cpu count of unit")
-	unitFlags.StringVar(&o.UnitConfig.MemorySize, FLAG_MEMORY_SIZE, "2Gi", "The memory size of unit")
-	unitFlags.StringVar(&o.UnitConfig.LogDiskSize, FLAG_LOG_DISK_SIZE, "4Gi", "The log disk size of unit")
+	unitFlags.IntVar(&o.UnitNumber, FLAG_UNIT_NUMBER, DEFAULT_UNIT_NUMBER, "unit number of the OBTenant")
+	unitFlags.Int64Var(&o.UnitConfig.MaxIops, FLAG_MAX_IOPS, DEFAULT_MAX_IOPS, "The max iops of unit")
+	unitFlags.Int64Var(&o.UnitConfig.MinIops, FLAG_MIN_IOPS, DEFAULT_MIN_IOPS, "The min iops of unit")
+	unitFlags.IntVar(&o.UnitConfig.IopsWeight, FLAG_IOPS_WEIGHT, DEFAULT_IOPS_WEIGHT, "The iops weight of unit")
+	unitFlags.StringVar(&o.UnitConfig.CPUCount, FLAG_CPU_COUNT, DEFAULT_CPU_COUNT, "The cpu count of unit")
+	unitFlags.StringVar(&o.UnitConfig.MemorySize, FLAG_MEMORY_SIZE, DEFAULT_MEMORY_SIZE, "The memory size of unit")
+	unitFlags.StringVar(&o.UnitConfig.LogDiskSize, FLAG_LOG_DISK_SIZE, DEFAULT_LOG_DISK_SIZE, "The log disk size of unit")
 	cmd.Flags().AddFlagSet(unitFlags)
 }
 
 // AddRestoreFlags add restore flags
 func (o *CreateOptions) AddRestoreFlags(cmd *cobra.Command) {
 	restoreFlags := pflag.NewFlagSet(FLAGSET_RESTORE, pflag.ContinueOnError)
-	restoreFlags.BoolVarP(&o.Restore, FLAG_RESTORE, "r", false, "Restore from backup files")
-	restoreFlags.StringVar(&o.RestoreType, FLAG_RESTORE_TYPE, "OSS", "The type of restore source, support OSS or NFS")
-	restoreFlags.StringVar(&o.Source.Restore.ArchiveSource, FLAG_ARCHIVE_SOURCE, "demo_tenant/log_archive_custom", "The archive source of restore")
+	restoreFlags.BoolVarP(&o.Restore, FLAG_RESTORE, "r", DEFAULT_RESTORE_FLAG, "Restore from backup files")
+	restoreFlags.StringVar(&o.RestoreType, FLAG_RESTORE_TYPE, DEFAULT_RESTORE_TYPE, "The type of restore source, support OSS or NFS")
+	restoreFlags.StringVar(&o.Source.Restore.ArchiveSource, FLAG_ARCHIVE_SOURCE, DEFAULT_ARCHIVE_SOURCE, "The archive source of restore")
 	restoreFlags.StringVar(&o.Source.Restore.BakEncryptionPassword, FLAG_BAK_ENCRYPTION_PASS, "", "The backup encryption password of obtenant")
-	restoreFlags.StringVar(&o.Source.Restore.BakDataSource, FLAG_BAK_DATA_SOURCE, "demo_tenant/data_backup_custom_enc", "The bak data source of restore")
+	restoreFlags.StringVar(&o.Source.Restore.BakDataSource, FLAG_BAK_DATA_SOURCE, DEFAULT_BAK_DATA_SOURCE, "The bak data source of restore")
 	restoreFlags.StringVar(&o.Source.Restore.OSSAccessID, FLAG_OSS_ACCESS_ID, "", "The oss access id of restore")
 	restoreFlags.StringVar(&o.Source.Restore.OSSAccessKey, FLAG_OSS_ACCESS_KEY, "", "The oss access key of restore")
-	restoreFlags.BoolVar(&o.Source.Restore.Until.Unlimited, FLAG_UNLIMITED, true, "time limited for restore")
+	restoreFlags.BoolVar(&o.Source.Restore.Until.Unlimited, FLAG_UNLIMITED, DEFAULT_UNLIMITED_FLAG, "time limited for restore")
 	restoreFlags.StringVar(&o.Timestamp, FLAG_UNTIL_TIMESTAMP, "", "timestamp for obtenant restore")
 	cmd.Flags().AddFlagSet(restoreFlags)
 }

--- a/internal/cli/tenant/delete.go
+++ b/internal/cli/tenant/delete.go
@@ -29,5 +29,5 @@ func NewDeleteOptions() *DeleteOptions {
 
 // AddFlags add basic flags for tenant management
 func (o *DeleteOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, "default", "namespace of ob tenant")
+	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob tenant")
 }

--- a/internal/cli/tenant/enter.go
+++ b/internal/cli/tenant/enter.go
@@ -57,6 +57,7 @@ const (
 
 // Default values for tenant management
 const (
+	// Default values for int and string flags
 	DEFAULT_NAMESPACE          = "default"
 	DEFAULT_CHARSET            = "utf8mb4"
 	DEFAULT_CONNECT_WHITE_LIST = "%"
@@ -70,7 +71,8 @@ const (
 	DEFAULT_RESTORE_TYPE       = "OSS"
 	DEFAULT_ARCHIVE_SOURCE     = "demo_tenant/log_archive_custom"
 	DEFAULT_BAK_DATA_SOURCE    = "demo_tenant/data_backup_custom_enc"
-	// default bool flags
+
+	// Default values for bool flags
 	DEFAULT_UNLIMITED_FLAG = true
 	DEFAULT_FORCE_FLAG     = false
 	DEFAULT_RESTORE_FLAG   = false

--- a/internal/cli/tenant/enter.go
+++ b/internal/cli/tenant/enter.go
@@ -13,8 +13,9 @@ See the Mulan PSL v2 for more details.
 */
 package tenant
 
+// Flags and FlagSets for tenant management
 const (
-	// Flagsets for tenant
+	// FlagSets for tenant
 	FLAGSET_UNIT    = "unit"
 	FLAGSET_RESTORE = "restore"
 	FLAGSET_ZONE    = "zone"
@@ -52,4 +53,25 @@ const (
 	FLAG_UNLIMITED           = "unlimited"
 	FLAG_UNTIL_TIMESTAMP     = "until-timestamp"
 	FLAG_PASSWD              = "password"
+)
+
+// Default values for tenant management
+const (
+	DEFAULT_NAMESPACE          = "default"
+	DEFAULT_CHARSET            = "utf8mb4"
+	DEFAULT_CONNECT_WHITE_LIST = "%"
+	DEFAULT_UNIT_NUMBER        = 1
+	DEFAULT_MAX_IOPS           = 1024
+	DEFAULT_MIN_IOPS           = 1024
+	DEFAULT_IOPS_WEIGHT        = 1
+	DEFAULT_CPU_COUNT          = "1"
+	DEFAULT_MEMORY_SIZE        = "2Gi"
+	DEFAULT_LOG_DISK_SIZE      = "4Gi"
+	DEFAULT_RESTORE_TYPE       = "OSS"
+	DEFAULT_ARCHIVE_SOURCE     = "demo_tenant/log_archive_custom"
+	DEFAULT_BAK_DATA_SOURCE    = "demo_tenant/data_backup_custom_enc"
+	// default bool flags
+	DEFAULT_UNLIMITED_FLAG = true
+	DEFAULT_FORCE_FLAG     = false
+	DEFAULT_RESTORE_FLAG   = false
 )

--- a/internal/cli/tenant/replaylog.go
+++ b/internal/cli/tenant/replaylog.go
@@ -72,8 +72,8 @@ func (o *ReplayLogOptions) Validate() error {
 
 // AddFlags add basic flags for tenant management
 func (o *ReplayLogOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, "default", "The namespace of OBTenant")
-	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", false, "force operation")
-	cmd.Flags().StringVar(&o.RestoreUntilOptions.Timestamp, FLAG_UNTIL_TIMESTAMP, "", "timestamp for obtenant restore,example: 2024-02-23 17:47:00")
-	cmd.Flags().BoolVar(&o.RestoreUntilOptions.Unlimited, FLAG_UNLIMITED, true, "time limit for obtenant restore")
+	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of OBTenant")
+	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", DEFAULT_FORCE_FLAG, "force operation")
+	cmd.Flags().StringVar(&o.RestoreUntilOptions.Timestamp, FLAG_UNTIL_TIMESTAMP, "", "timestamp for OBTenant restore,example: 2024-02-23 17:47:00")
+	cmd.Flags().BoolVar(&o.RestoreUntilOptions.Unlimited, FLAG_UNLIMITED, DEFAULT_UNLIMITED_FLAG, "time limit for OBTenant restore")
 }

--- a/internal/cli/tenant/scale.go
+++ b/internal/cli/tenant/scale.go
@@ -117,20 +117,20 @@ func (o *ScaleOptions) Validate() error {
 
 // AddFlags for scale options
 func (o *ScaleOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, "default", "namespace of OBTenant")
-	cmd.Flags().IntVar(&o.UnitNumber, FLAG_UNIT_NUMBER, 1, "unit-number of pools")
-	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", false, "force operation")
+	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of OBTenant")
+	cmd.Flags().IntVar(&o.UnitNumber, FLAG_UNIT_NUMBER, DEFAULT_UNIT_NUMBER, "unit-number of pools")
+	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", DEFAULT_FORCE_FLAG, "force operation")
 	o.AddUnitFlags(cmd)
 }
 
 // AddUnitFlags add unit-resource-related flags
 func (o *ScaleOptions) AddUnitFlags(cmd *cobra.Command) {
 	unitFlags := pflag.NewFlagSet(FLAGSET_UNIT, pflag.ContinueOnError)
-	unitFlags.Int64Var(&o.UnitConfig.MaxIops, FLAG_MAX_IOPS, 1024, "The max iops of unit")
-	unitFlags.Int64Var(&o.UnitConfig.MinIops, FLAG_MIN_IOPS, 1024, "The min iops of unit")
-	unitFlags.IntVar(&o.UnitConfig.IopsWeight, FLAG_IOPS_WEIGHT, 1, "The iops weight of unit")
-	unitFlags.StringVar(&o.UnitConfig.CPUCount, FLAG_CPU_COUNT, "1", "The cpu count of unit")
-	unitFlags.StringVar(&o.UnitConfig.MemorySize, FLAG_MEMORY_SIZE, "2Gi", "The memory size of unit")
-	unitFlags.StringVar(&o.UnitConfig.LogDiskSize, FLAG_LOG_DISK_SIZE, "4Gi", "The log disk size of unit")
+	unitFlags.Int64Var(&o.UnitConfig.MaxIops, FLAG_MAX_IOPS, DEFAULT_MAX_IOPS, "The max iops of unit")
+	unitFlags.Int64Var(&o.UnitConfig.MinIops, FLAG_MIN_IOPS, DEFAULT_MIN_IOPS, "The min iops of unit")
+	unitFlags.IntVar(&o.UnitConfig.IopsWeight, FLAG_IOPS_WEIGHT, DEFAULT_IOPS_WEIGHT, "The iops weight of unit")
+	unitFlags.StringVar(&o.UnitConfig.CPUCount, FLAG_CPU_COUNT, DEFAULT_CPU_COUNT, "The cpu count of unit")
+	unitFlags.StringVar(&o.UnitConfig.MemorySize, FLAG_MEMORY_SIZE, DEFAULT_MEMORY_SIZE, "The memory size of unit")
+	unitFlags.StringVar(&o.UnitConfig.LogDiskSize, FLAG_LOG_DISK_SIZE, DEFAULT_LOG_DISK_SIZE, "The log disk size of unit")
 	cmd.Flags().AddFlagSet(unitFlags)
 }

--- a/internal/cli/tenant/show.go
+++ b/internal/cli/tenant/show.go
@@ -29,5 +29,5 @@ func NewShowOptions() *ShowOptions {
 
 // AddFlags add basic flags for tenant management
 func (o *ShowOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, "default", "namespace of ob cluster")
+	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob cluster")
 }

--- a/internal/cli/tenant/switchover.go
+++ b/internal/cli/tenant/switchover.go
@@ -62,6 +62,6 @@ func GetSwitchOverOperation(o *SwitchOverOptions) *v1alpha1.OBTenantOperation {
 
 // AddFlags add basic flags for tenant management
 func (o *SwitchOverOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, "default", "namespace of ob tenant")
-	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", false, "force operation")
+	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob tenant")
+	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", DEFAULT_FORCE_FLAG, "force operation")
 }

--- a/internal/cli/tenant/update.go
+++ b/internal/cli/tenant/update.go
@@ -59,7 +59,7 @@ func NewUpdateOptions() *UpdateOptions {
 func (o *UpdateOptions) Parse(cmd *cobra.Command, args []string) error {
 	o.Name = args[0]
 	o.Cmd = cmd
-	if o.CheckIfFlagChanged("priority") {
+	if o.CheckIfFlagChanged(FLAG_ZONE_PRIORITY) {
 		pools, err := utils.MapZonesToPools(o.ZonePriority)
 		if err != nil {
 			return err

--- a/internal/cli/tenant/update.go
+++ b/internal/cli/tenant/update.go
@@ -193,21 +193,21 @@ func (o *UpdateOptions) Validate() error {
 
 // AddFlags add basic flags for tenant management
 func (o *UpdateOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, "default", "The namespace of OBTenant")
+	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of OBTenant")
 	cmd.Flags().StringVar(&o.ConnectWhiteList, FLAG_CONNECT_WHITE_LIST, "", "The connect white list using in ob tenant")
 	cmd.Flags().StringToStringVar(&o.ZonePriority, FLAG_ZONE_PRIORITY, nil, "zone priority config of OBTenant")
-	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", false, "force operation")
+	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", DEFAULT_FORCE_FLAG, "force operation")
 	o.AddUnitFlags(cmd)
 }
 
 // AddUnitFlags add unit-resource-related flags
 func (o *UpdateOptions) AddUnitFlags(cmd *cobra.Command) {
 	unitFlags := pflag.NewFlagSet(FLAGSET_UNIT, pflag.ContinueOnError)
-	unitFlags.Int64Var(&o.UnitConfig.MaxIops, FLAG_MAX_IOPS, 1024, "The max iops of unit")
-	unitFlags.Int64Var(&o.UnitConfig.MinIops, FLAG_MIN_IOPS, 1024, "The min iops of unit")
-	unitFlags.IntVar(&o.UnitConfig.IopsWeight, FLAG_IOPS_WEIGHT, 1, "The iops weight of unit")
-	unitFlags.StringVar(&o.UnitConfig.CPUCount, FLAG_CPU_COUNT, "1", "The cpu count of unit")
-	unitFlags.StringVar(&o.UnitConfig.MemorySize, FLAG_MEMORY_SIZE, "2Gi", "The memory size of unit")
-	unitFlags.StringVar(&o.UnitConfig.LogDiskSize, FLAG_LOG_DISK_SIZE, "4Gi", "The log disk size of unit")
+	unitFlags.Int64Var(&o.UnitConfig.MaxIops, FLAG_MAX_IOPS, DEFAULT_MAX_IOPS, "The max iops of unit")
+	unitFlags.Int64Var(&o.UnitConfig.MinIops, FLAG_MIN_IOPS, DEFAULT_MIN_IOPS, "The min iops of unit")
+	unitFlags.IntVar(&o.UnitConfig.IopsWeight, FLAG_IOPS_WEIGHT, DEFAULT_IOPS_WEIGHT, "The iops weight of unit")
+	unitFlags.StringVar(&o.UnitConfig.CPUCount, FLAG_CPU_COUNT, DEFAULT_CPU_COUNT, "The cpu count of unit")
+	unitFlags.StringVar(&o.UnitConfig.MemorySize, FLAG_MEMORY_SIZE, DEFAULT_MEMORY_SIZE, "The memory size of unit")
+	unitFlags.StringVar(&o.UnitConfig.LogDiskSize, FLAG_LOG_DISK_SIZE, DEFAULT_LOG_DISK_SIZE, "The log disk size of unit")
 	cmd.Flags().AddFlagSet(unitFlags)
 }

--- a/internal/cli/tenant/update.go
+++ b/internal/cli/tenant/update.go
@@ -56,6 +56,7 @@ func NewUpdateOptions() *UpdateOptions {
 		UnitConfig:          &param.UnitConfig{},
 	}
 }
+
 func (o *UpdateOptions) Parse(cmd *cobra.Command, args []string) error {
 	o.Name = args[0]
 	o.Cmd = cmd

--- a/internal/cli/tenant/upgrade.go
+++ b/internal/cli/tenant/upgrade.go
@@ -51,6 +51,6 @@ func GetUpgradeOperation(o *UpgradeOptions) *v1alpha1.OBTenantOperation {
 
 // AddFlags add basic flags for tenant management
 func (o *UpgradeOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, "default", "The namespace of the tenant")
-	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", false, "force operation")
+	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of the tenant")
+	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", DEFAULT_FORCE_FLAG, "force operation")
 }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
- Move default values to `enter.go` in tenant and cluster management.
- Change validate strategy in cluster/update.go


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
https://github.com/oceanbase/ob-operator/pull/577#pullrequestreview-2336970572 