### PR TITLE
fix：After deleting a cluster, clicking the browser back page jumps 

### DIFF
--- a/ui/src/pages/Cluster/Detail/Overview/index.tsx
+++ b/ui/src/pages/Cluster/Detail/Overview/index.tsx
@@ -50,7 +50,7 @@ const ClusterOverview: React.FC = () => {
           defaultMessage: '删除成功',
         }),
       );
-      history.push('/cluster');
+      history.replace('/cluster');
     }
   };
 

--- a/ui/src/pages/OBProxy/Detail/Overview/index.tsx
+++ b/ui/src/pages/OBProxy/Detail/Overview/index.tsx
@@ -45,7 +45,7 @@ export default function Overview() {
           defaultMessage: '删除成功',
         }),
       );
-      history.push('/obproxy');
+      history.replace('/obproxy');
     }
   };
 

--- a/ui/src/pages/Tenant/Detail/Overview/index.tsx
+++ b/ui/src/pages/Tenant/Detail/Overview/index.tsx
@@ -82,7 +82,7 @@ export default function TenantOverview() {
           defaultMessage: '删除成功',
         }),
       );
-      history.push('/tenant');
+      history.replace('/tenant');
     }
   };
 
@@ -211,7 +211,7 @@ export default function TenantOverview() {
 
   const operateSuccess = () => {
     setTimeout(() => {
-      getTenantDetail({ ns:ns!, name:name! });
+      getTenantDetail({ ns: ns!, name: name! });
     }, 1000);
   };
   const header = () => {


### PR DESCRIPTION
… an error

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

After deleting a cluster, clicking the browser back page jumps to an error

## Solution Description
<!-- Please clearly and concisely describe your solution. -->
![image](https://github.com/user-attachments/assets/6bb210ec-0486-46f2-b449-b2e48c213d0c)
