### PR TITLE
Set environment variable for obagent to overwrite host ip config

### DIFF
--- a/internal/const/obagent/obagent.go
+++ b/internal/const/obagent/obagent.go
@@ -13,6 +13,10 @@ See the Mulan PSL v2 for more details.
 package monitor
 
 const (
+	LocalHostAddress = "127.0.0.1"
+)
+
+const (
 	HttpPort  = 8088
 	PprofPort = 8089
 )
@@ -42,6 +46,7 @@ const (
 	EnvMonitorUser     = "MONITOR_USER"
 	EnvMonitorPASSWORD = "MONITOR_PASSWORD"
 	EnvOBMonitorStatus = "OB_MONITOR_STATUS"
+	EnvHostIp          = "HOST_IP"
 )
 
 const (

--- a/internal/resource/observer/utils.go
+++ b/internal/resource/observer/utils.go
@@ -400,11 +400,11 @@ func (m *OBServerManager) createMonitorContainer(obcluster *v1alpha1.OBCluster) 
 	if modeAnnoExist {
 		switch mode {
 		case oceanbaseconst.ModeStandalone:
-			envMode := corev1.EnvVar{
-				Name:  "STANDALONE",
-				Value: oceanbaseconst.ModeStandalone,
+			envHostIp := corev1.EnvVar{
+				Name:  obagentconst.EnvHostIp,
+				Value: obagentconst.LocalHostAddress,
 			}
-			env = append(env, envMode)
+			env = append(env, envHostIp)
 		case oceanbaseconst.ModeService:
 			svc, err := m.getSvc()
 			if err != nil {
@@ -414,11 +414,11 @@ func (m *OBServerManager) createMonitorContainer(obcluster *v1alpha1.OBCluster) 
 					m.Logger.Error(err, "Failed to get svc")
 				}
 			} else {
-				envSvcIp := corev1.EnvVar{
-					Name:  "SVC_IP",
+				envHostIp := corev1.EnvVar{
+					Name:  obagentconst.EnvHostIp,
 					Value: svc.Spec.ClusterIP,
 				}
-				env = append(env, envSvcIp)
+				env = append(env, envHostIp)
 			}
 		}
 	}
@@ -571,11 +571,11 @@ func (m *OBServerManager) createOBServerContainer(obcluster *v1alpha1.OBCluster)
 	if modeAnnoExist {
 		switch mode {
 		case oceanbaseconst.ModeStandalone:
-			envHostIp := corev1.EnvVar{
-				Name:  obagentconst.EnvHostIp,
-				Value: obagentconst.LocalHostAddress,
+			envMode := corev1.EnvVar{
+				Name:  "STANDALONE",
+				Value: oceanbaseconst.ModeStandalone,
 			}
-			env = append(env, envHostIp)
+			env = append(env, envMode)
 		case oceanbaseconst.ModeService:
 			svc, err := m.getSvc()
 			if err != nil {
@@ -585,15 +585,14 @@ func (m *OBServerManager) createOBServerContainer(obcluster *v1alpha1.OBCluster)
 					m.Logger.Error(err, "Failed to get svc")
 				}
 			} else {
-				envHostIp := corev1.EnvVar{
-					Name:  obagentconst.EnvHostIp,
+				envSvcIp := corev1.EnvVar{
+					Name:  "SVC_IP",
 					Value: svc.Spec.ClusterIP,
 				}
-				env = append(env, envHostIp)
+				env = append(env, envSvcIp)
 			}
 		}
 	}
-
 	startupParameters := make([]string, 0)
 	for _, parameter := range obcluster.Spec.Parameters {
 		reserved := false


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Set environment variable for obagent to overwrite host ip config
1. set HOST_IP to 127.0.0.1 when cluster mode is standalone
2. set HOST_IP to service address when cluster mode is service


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
