### PR TITLE
build: Add a replace block to the go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -179,3 +179,37 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace (
+	k8s.io/api => k8s.io/api v0.29.3
+	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.29.3
+	k8s.io/apimachinery => k8s.io/apimachinery v0.29.3
+	k8s.io/apiserver => k8s.io/apiserver v0.29.3
+	k8s.io/cli-runtime => k8s.io/cli-runtime v0.29.3
+	k8s.io/client-go => k8s.io/client-go v0.29.3
+	k8s.io/cloud-provider => k8s.io/cloud-provider v0.29.3
+	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.29.3
+	k8s.io/code-generator => k8s.io/code-generator v0.29.3
+	k8s.io/component-base => k8s.io/component-base v0.29.3
+	k8s.io/component-helpers => k8s.io/component-helpers v0.29.3
+	k8s.io/controller-manager => k8s.io/controller-manager v0.29.3
+	k8s.io/cri-api => k8s.io/cri-api v0.29.3
+	k8s.io/cri-client => k8s.io/cri-client v0.29.3
+	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.29.3
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.29.3
+	k8s.io/endpointslice => k8s.io/endpointslice v0.29.3
+	k8s.io/kms => k8s.io/kms v0.29.3
+	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.29.3
+	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.29.3
+	k8s.io/kube-proxy => k8s.io/kube-proxy v0.29.3
+	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.29.3
+	k8s.io/kubectl => k8s.io/kubectl v0.29.3
+	k8s.io/kubelet => k8s.io/kubelet v0.29.3
+	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.29.3
+	k8s.io/metrics => k8s.io/metrics v0.29.3
+	k8s.io/mount-utils => k8s.io/mount-utils v0.29.3
+	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.29.3
+	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.29.3
+	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.29.3
+	k8s.io/sample-controller => k8s.io/sample-controller v0.29.3
+)


### PR DESCRIPTION
Added the replace block in go.mod to solve the problem that the k8s module could not be loaded during goland IDE development