### PR TITLE
fix: update shorthand for namespace and move shorthands to `enter.go`

### DIFF
--- a/internal/cli/backup/create.go
+++ b/internal/cli/backup/create.go
@@ -219,7 +219,7 @@ func (o *CreateOptions) SetRequiredFlags(cmd *cobra.Command) {
 // AddBaseFlags adds the base flags for the create command
 func (o *CreateOptions) AddBaseFlags(cmd *cobra.Command) {
 	baseFlags := cmd.Flags()
-	baseFlags.StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of the ob tenant")
+	baseFlags.StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of the ob tenant")
 	baseFlags.StringVar(&o.DestType, FLAG_DEST_TYPE, DEFAULT_DEST_TYPE, "The destination type of the backup policy, currently support OSS or NFS")
 	baseFlags.StringVar(&o.ArchivePath, FLAG_ARCHIVE_PATH, "", "The archive path of the backup policy")
 	baseFlags.StringVar(&o.BakDataPath, FLAG_BAK_DATA_PATH, "", "The backup data path of the backup policy")

--- a/internal/cli/backup/delete.go
+++ b/internal/cli/backup/delete.go
@@ -50,6 +50,6 @@ func DeleteTenantBackupPolicy(ctx context.Context, o *DeleteOptions) error {
 
 // AddFlags add basic flags for tenant management
 func (o *DeleteOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of the ob tenant")
-	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", DEFAULT_FORCE, "Force delete the ob tenant backup policy")
+	cmd.Flags().StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of the ob tenant")
+	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, SHORTHAND_FORCE, DEFAULT_FORCE, "Force delete the ob tenant backup policy")
 }

--- a/internal/cli/backup/enter.go
+++ b/internal/cli/backup/enter.go
@@ -66,3 +66,10 @@ const (
 	DEFAULT_JOBTYPE             = "ALL"
 	DEFAULT_LIMIT               = 0
 )
+
+// Shorthand for backup policy management
+const (
+	SHORTHAND_NAMESPACE = "n"
+	SHORTHAND_FORCE     = "f"
+	SHORTHAND_TYPE      = "t"
+)

--- a/internal/cli/backup/list.go
+++ b/internal/cli/backup/list.go
@@ -29,5 +29,5 @@ func NewListOptions() *ListOptions {
 
 // AddFlags adds flags for list command
 func (o *ListOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of ob tenant, if not set, use default namespace")
+	cmd.Flags().StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of ob tenant, if not set, use default namespace")
 }

--- a/internal/cli/backup/pause.go
+++ b/internal/cli/backup/pause.go
@@ -28,5 +28,5 @@ func NewPauseOptions() *PauseOptions {
 }
 
 func (o *PauseOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of the tenant")
+	cmd.Flags().StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of the tenant")
 }

--- a/internal/cli/backup/resume.go
+++ b/internal/cli/backup/resume.go
@@ -28,5 +28,5 @@ func NewResumeOptions() *ResumeOptions {
 }
 
 func (o *ResumeOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of the tenant")
+	cmd.Flags().StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of the tenant")
 }

--- a/internal/cli/backup/show.go
+++ b/internal/cli/backup/show.go
@@ -60,7 +60,7 @@ func ListBackupJobs(ctx context.Context, policyName string, o *ShowOptions) (*v1
 
 // AddFlags adds flags for show command
 func (o *ShowOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of ob tenant, if not set, use default namespace")
-	cmd.Flags().StringVar(&o.jobType, FLAG_JOB_TYPE, DEFAULT_JOBTYPE, "The type of backup job, support FULL, INC, CLEAN, ARCHIVE, ALL")
+	cmd.Flags().StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of ob tenant, if not set, use default namespace")
+	cmd.Flags().StringVarP(&o.jobType, FLAG_JOB_TYPE, SHORTHAND_TYPE, DEFAULT_JOBTYPE, "The type of backup job, support FULL, INC, CLEAN, ARCHIVE, ALL")
 	cmd.Flags().Int64Var(&o.limit, FLAG_LIMIT, DEFAULT_LIMIT, "The number of backup jobs to show")
 }

--- a/internal/cli/backup/update.go
+++ b/internal/cli/backup/update.go
@@ -117,7 +117,7 @@ func (o *UpdateOptions) AddFlags(cmd *cobra.Command) {
 // AddBaseFlags adds the base flags for the create command
 func (o *UpdateOptions) AddBaseFlags(cmd *cobra.Command) {
 	baseFlags := cmd.Flags()
-	baseFlags.StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of the ob tenant")
+	baseFlags.StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of the ob tenant")
 	baseFlags.IntVar(&o.JobKeepDays, FLAG_JOB_KEEP_DAYS, DEFAULT_JOB_KEEP_DAYS, "The number of days to keep the backup job")
 	baseFlags.IntVar(&o.RecoveryDays, FLAG_RECOVERY_DAYS, DEFAULT_RECOVERY_DAYS, "The number of days to keep the backup recovery")
 	baseFlags.IntVar(&o.PieceIntervalDays, FLAG_PIECE_INTERVAL_DAYS, DEFAULT_PIECE_INTERVAL_DAYS, "The number of days to switch the backup piece")

--- a/internal/cli/cluster/create.go
+++ b/internal/cli/cluster/create.go
@@ -344,17 +344,17 @@ func (o *CreateOptions) SetRequiredFlags(cmd *cobra.Command) {
 // AddZoneFlags adds the zone-related flags to the command.
 func (o *CreateOptions) AddZoneFlags(cmd *cobra.Command) {
 	zoneFlags := pflag.NewFlagSet(FLAGSET_ZONE, pflag.ContinueOnError)
-	zoneFlags.StringToStringVarP(&o.Zones, FLAG_ZONES, "z", map[string]string{"z1": "1"}, "The zones of the cluster, e.g. '--zones=<zone>=<replica>'")
+	zoneFlags.StringToStringVarP(&o.Zones, FLAG_ZONES, SHORTHAND_ZONES, map[string]string{"z1": "1"}, "The zones of the cluster, e.g. '--zones=<zone>=<replica>'")
 	cmd.Flags().AddFlagSet(zoneFlags)
 }
 
 // AddBaseFlags adds the base flags to the command.
 func (o *CreateOptions) AddBaseFlags(cmd *cobra.Command) {
 	baseFlags := cmd.Flags()
-	baseFlags.StringVarP(&o.ClusterName, FLAG_CLUSTER_NAME, "n", "", "Cluster name, if not specified, use resource name in k8s instead")
-	baseFlags.StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of the cluster")
+	baseFlags.StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of the cluster")
+	baseFlags.StringVarP(&o.RootPassword, FLAG_ROOT_PASSWORD, SHORTHAND_PASSWD, "", "The root password of the cluster")
+	baseFlags.StringVar(&o.ClusterName, FLAG_CLUSTER_NAME, "", "Cluster name, if not specified, use resource name in k8s instead")
 	baseFlags.Int64Var(&o.ClusterId, FLAG_CLUSTER_ID, DEFAULT_ID, "The id of the cluster")
-	baseFlags.StringVarP(&o.RootPassword, FLAG_ROOT_PASSWORD, "p", "", "The root password of the cluster")
 	baseFlags.StringVar(&o.Mode, FLAG_MODE, DEFAULT_MODE, "The mode of the cluster")
 }
 

--- a/internal/cli/cluster/delete.go
+++ b/internal/cli/cluster/delete.go
@@ -29,5 +29,5 @@ func NewDeleteOptions() *DeleteOptions {
 
 // AddFlags add basic flags for cluster management
 func (o *DeleteOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob cluster")
+	cmd.Flags().StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob cluster")
 }

--- a/internal/cli/cluster/enter.go
+++ b/internal/cli/cluster/enter.go
@@ -98,7 +98,13 @@ const (
 )
 
 // Error messages for cluster management
-
 const (
 	ErrInvalidClusterType = "invalid cluster type"
+)
+
+// Shorthand for cluster management
+const (
+	SHORTHAND_ZONES     = "z"
+	SHORTHAND_NAMESPACE = "n"
+	SHORTHAND_PASSWD    = "p"
 )

--- a/internal/cli/cluster/scale.go
+++ b/internal/cli/cluster/scale.go
@@ -167,7 +167,7 @@ func (o *ScaleOptions) Validate() error {
 
 // AddFlags for scale options
 func (o *ScaleOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob cluster")
-	cmd.Flags().StringToStringVar(&o.Zones, FLAG_ZONES, nil, "The zone of the cluster, e.g. '--zones=<zone>=<replica>', set replicas to 0 to delete the zone, only one operation of adding, deleting or modifying is allowd at a time, required")
+	cmd.Flags().StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob cluster")
+	cmd.Flags().StringToStringVarP(&o.Zones, FLAG_ZONES, SHORTHAND_ZONES, nil, "The zone of the cluster, e.g. '--zones=<zone>=<replica>', set replicas to 0 to delete the zone, only one operation of adding, deleting or modifying is allowd at a time, required")
 	_ = cmd.MarkFlagRequired(FLAG_ZONES)
 }

--- a/internal/cli/cluster/show.go
+++ b/internal/cli/cluster/show.go
@@ -29,5 +29,5 @@ func NewShowOptions() *ShowOptions {
 
 // AddFlags add basic flags for cluster management
 func (o *ShowOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of the ob cluster")
+	cmd.Flags().StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "namespace of the ob cluster")
 }

--- a/internal/cli/cluster/update.go
+++ b/internal/cli/cluster/update.go
@@ -128,7 +128,7 @@ func (o *UpdateOptions) Complete() error {
 
 // AddFlags for update options
 func (o *UpdateOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob cluster")
+	cmd.Flags().StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob cluster")
 	cmd.Flags().Int64Var(&o.Resource.Cpu, FLAG_OBSERVER_CPU, DEFAULT_OBSERVER_CPU, "The cpu of the observer")
 	cmd.Flags().Int64Var(&o.Resource.MemoryGB, FLAG_OBSERVER_MEMORY, DEFAULT_OBSERVER_MEMORY, "The memory of the observer")
 	cmd.Flags().StringVar(&o.Storage.Data.StorageClass, FLAG_DATA_STORAGE_CLASS, "", "The storage class of the data storage")

--- a/internal/cli/cluster/upgrade.go
+++ b/internal/cli/cluster/upgrade.go
@@ -61,7 +61,7 @@ func (o *UpgradeOptions) Validate() error {
 
 // AddFlags for upgrade options
 func (o *UpgradeOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob cluster")
+	cmd.Flags().StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob cluster")
 	cmd.Flags().StringVar(&o.Image, FLAG_OBSERVER_IMAGE, "", "The image of observer") // set image to null, avoid image downgrade
 	_ = cmd.MarkFlagRequired(FLAG_OBSERVER_IMAGE)
 }

--- a/internal/cli/tenant/activate.go
+++ b/internal/cli/tenant/activate.go
@@ -53,6 +53,6 @@ func GetActivateOperation(o *ActivateOptions) *v1alpha1.OBTenantOperation {
 
 // AddFlags add basic flags for tenant management
 func (o *ActivateOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob tenant")
-	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", DEFAULT_FORCE_FLAG, "If the operation is a force operation")
+	cmd.Flags().StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob tenant")
+	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, SHORTHAND_FORCE, DEFAULT_FORCE_FLAG, "If the operation is a force operation")
 }

--- a/internal/cli/tenant/changepwd.go
+++ b/internal/cli/tenant/changepwd.go
@@ -87,8 +87,8 @@ func (o *ChangePwdOptions) Validate() error {
 }
 
 func (o *ChangePwdOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob tenant")
-	cmd.Flags().StringVarP(&o.Password, FLAG_PASSWD, "p", "", "new password of ob tenant, required")
-	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", DEFAULT_FORCE_FLAG, "force operation")
+	cmd.Flags().StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob tenant")
+	cmd.Flags().StringVarP(&o.Password, FLAG_PASSWD, SHORTHAND_PASSWD, "", "new password of ob tenant, required")
+	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, SHORTHAND_FORCE, DEFAULT_FORCE_FLAG, "force operation")
 	_ = cmd.MarkFlagRequired(FLAG_PASSWD)
 }

--- a/internal/cli/tenant/create.go
+++ b/internal/cli/tenant/create.go
@@ -404,11 +404,11 @@ func (o *CreateOptions) SetRequiredFlags(cmd *cobra.Command) {
 // AddBaseFlags add base flags
 func (o *CreateOptions) AddBaseFlags(cmd *cobra.Command) {
 	baseFlags := cmd.Flags()
-	baseFlags.StringVarP(&o.TenantName, FLAG_TENANT_NAME, "n", "", "Tenant name, if not specified, use name in k8s instead")
+	baseFlags.StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of the tenant")
+	baseFlags.StringVarP(&o.RootPassword, FLAG_ROOTPASSWD, SHORTHAND_PASSWD, "", "The root password of the primary tenant, if not specified, generate a random password")
+	baseFlags.StringVarP(&o.Charset, FLAG_CHARSET, SHORTHAND_CHARSET, DEFAULT_CHARSET, "The charset used in ob tenant")
+	baseFlags.StringVar(&o.TenantName, FLAG_TENANT_NAME, "", "Tenant name, if not specified, use name in k8s instead")
 	baseFlags.StringVar(&o.ClusterName, FLAG_CLUSTER_NAME, "", "The cluster name tenant belonged to in k8s, required")
-	baseFlags.StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of the tenant")
-	baseFlags.StringVarP(&o.RootPassword, FLAG_ROOTPASSWD, "p", "", "The root password of the primary tenant, if not specified, generate a random password")
-	baseFlags.StringVarP(&o.Charset, FLAG_CHARSET, "c", DEFAULT_CHARSET, "The charset used in ob tenant")
 	baseFlags.StringVar(&o.ConnectWhiteList, FLAG_CONNECT_WHITE_LIST, DEFAULT_CONNECT_WHITE_LIST, "The connect white list used in ob tenant")
 	baseFlags.StringVar(&o.From, FLAG_FROM, "", "The source tenant to create a standby tenant or restore the tenant")
 }
@@ -436,7 +436,7 @@ func (o *CreateOptions) AddUnitFlags(cmd *cobra.Command) {
 // AddRestoreFlags add restore flags
 func (o *CreateOptions) AddRestoreFlags(cmd *cobra.Command) {
 	restoreFlags := pflag.NewFlagSet(FLAGSET_RESTORE, pflag.ContinueOnError)
-	restoreFlags.BoolVarP(&o.Restore, FLAG_RESTORE, "r", DEFAULT_RESTORE_FLAG, "Restore from backup files, set to true to restore a tenant, also need the `from` flag to specify the source tenant")
+	restoreFlags.BoolVarP(&o.Restore, FLAG_RESTORE, SHORTHAND_RESTORE, DEFAULT_RESTORE_FLAG, "Restore from backup files, set to true to restore a tenant, also need the `from` flag to specify the source tenant")
 	restoreFlags.StringVar(&o.RestoreType, FLAG_RESTORE_TYPE, DEFAULT_RESTORE_TYPE, "The type of restore source, support OSS or NFS")
 	restoreFlags.StringVar(&o.Source.Restore.ArchiveSource, FLAG_ARCHIVE_SOURCE, "", "The archive source of restore")
 	restoreFlags.StringVar(&o.Source.Restore.BakEncryptionPassword, FLAG_BAK_ENCRYPTION_PASS, "", "The backup encryption password of obtenant")

--- a/internal/cli/tenant/delete.go
+++ b/internal/cli/tenant/delete.go
@@ -29,5 +29,5 @@ func NewDeleteOptions() *DeleteOptions {
 
 // AddFlags add basic flags for tenant management
 func (o *DeleteOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob tenant")
+	cmd.Flags().StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob tenant")
 }

--- a/internal/cli/tenant/enter.go
+++ b/internal/cli/tenant/enter.go
@@ -84,3 +84,12 @@ const (
 const (
 	FLAG_TENANT_NAME_IN_K8S = "tenant-name-in-k8s"
 )
+
+// Shorthand for tenant management
+const (
+	SHORTHAND_NAMESPACE = "n"
+	SHORTHAND_CHARSET   = "c"
+	SHORTHAND_FORCE     = "f"
+	SHORTHAND_RESTORE   = "r"
+	SHORTHAND_PASSWD    = "p"
+)

--- a/internal/cli/tenant/list.go
+++ b/internal/cli/tenant/list.go
@@ -29,5 +29,5 @@ func NewListOptions() *ListOptions {
 }
 
 func (o *ListOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "The namespace tenant belonged to in k8s, if not set, use the default namespace")
+	cmd.Flags().StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_PASSWD, DEFAULT_NAMESPACE, "The namespace tenant belonged to in k8s, if not set, use the default namespace")
 }

--- a/internal/cli/tenant/replaylog.go
+++ b/internal/cli/tenant/replaylog.go
@@ -72,8 +72,8 @@ func (o *ReplayLogOptions) Validate() error {
 
 // AddFlags add basic flags for tenant management
 func (o *ReplayLogOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of OBTenant")
-	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", DEFAULT_FORCE_FLAG, "If the operation is a force operation")
+	cmd.Flags().StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of OBTenant")
+	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, SHORTHAND_FORCE, DEFAULT_FORCE_FLAG, "If the operation is a force operation")
 	cmd.Flags().StringVar(&o.RestoreUntilOptions.Timestamp, FLAG_UNTIL_TIMESTAMP, "", "timestamp for OBTenant restore,example: 2024-02-23 17:47:00")
 	cmd.Flags().BoolVar(&o.RestoreUntilOptions.Unlimited, FLAG_UNLIMITED, DEFAULT_UNLIMITED_FLAG, "time limit for OBTenant restore")
 }

--- a/internal/cli/tenant/scale.go
+++ b/internal/cli/tenant/scale.go
@@ -117,9 +117,9 @@ func (o *ScaleOptions) Validate() error {
 
 // AddFlags for scale options
 func (o *ScaleOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of OBTenant")
+	cmd.Flags().StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "namespace of OBTenant")
+	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, SHORTHAND_FORCE, DEFAULT_FORCE_FLAG, "If the operation is a force operation")
 	cmd.Flags().IntVar(&o.UnitNumber, FLAG_UNIT_NUMBER, DEFAULT_UNIT_NUMBER, "unit-number of pools")
-	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", DEFAULT_FORCE_FLAG, "If the operation is a force operation")
 	o.AddUnitFlags(cmd)
 }
 

--- a/internal/cli/tenant/show.go
+++ b/internal/cli/tenant/show.go
@@ -29,5 +29,5 @@ func NewShowOptions() *ShowOptions {
 
 // AddFlags add basic flags for tenant management
 func (o *ShowOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob cluster")
+	cmd.Flags().StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob cluster")
 }

--- a/internal/cli/tenant/switchover.go
+++ b/internal/cli/tenant/switchover.go
@@ -62,6 +62,6 @@ func GetSwitchOverOperation(o *SwitchOverOptions) *v1alpha1.OBTenantOperation {
 
 // AddFlags add basic flags for tenant management
 func (o *SwitchOverOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob tenant")
-	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", DEFAULT_FORCE_FLAG, "If the operation is a force operation")
+	cmd.Flags().StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "namespace of ob tenant")
+	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, SHORTHAND_FORCE, DEFAULT_FORCE_FLAG, "If the operation is a force operation")
 }

--- a/internal/cli/tenant/update.go
+++ b/internal/cli/tenant/update.go
@@ -200,9 +200,9 @@ func (o *UpdateOptions) Validate() error {
 
 // AddFlags add basic flags for tenant management
 func (o *UpdateOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of OBTenant")
+	cmd.Flags().StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of OBTenant")
+	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, SHORTHAND_FORCE, DEFAULT_FORCE_FLAG, "If the operation is a force operation")
 	cmd.Flags().StringVar(&o.ConnectWhiteList, FLAG_CONNECT_WHITE_LIST, "", "The connect white list of ob tenant")
 	cmd.Flags().StringToStringVar(&o.ZonePriority, FLAG_ZONE_PRIORITY, nil, "The zone priority config of OBTenant, e.g. --priority=<zone>=<priority>, set priority to 0 to delete zone from the unit pool, required")
-	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", DEFAULT_FORCE_FLAG, "If the operation is a force operation")
 	_ = cmd.MarkFlagRequired(FLAG_ZONE_PRIORITY)
 }

--- a/internal/cli/tenant/upgrade.go
+++ b/internal/cli/tenant/upgrade.go
@@ -51,6 +51,6 @@ func GetUpgradeOperation(o *UpgradeOptions) *v1alpha1.OBTenantOperation {
 
 // AddFlags add basic flags for tenant management
 func (o *UpgradeOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Namespace, FLAG_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of the tenant")
-	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, "f", DEFAULT_FORCE_FLAG, "If the operation is a force operation")
+	cmd.Flags().StringVarP(&o.Namespace, FLAG_NAMESPACE, SHORTHAND_NAMESPACE, DEFAULT_NAMESPACE, "The namespace of the tenant")
+	cmd.Flags().BoolVarP(&o.force, FLAG_FORCE, SHORTHAND_FORCE, DEFAULT_FORCE_FLAG, "If the operation is a force operation")
 }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
1. update shorthand for namespace 
2. move shorthands for each command to `enter.go`


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
