### PR TITLE
集群详情页增加集群参数页相关

### DIFF
--- a/ui/config/routes.ts
+++ b/ui/config/routes.ts
@@ -125,6 +125,11 @@ export default [
                 name: '集群下的租户',
               },
               {
+                path: 'parameters',
+                component: 'Cluster/Detail/Parameters',
+                name: '集群参数',
+              },
+              {
                 path: 'connection',
                 component: 'Cluster/Detail/Connection',
                 name: '连接集群',

--- a/ui/src/components/TableFilterDropdown.tsx
+++ b/ui/src/components/TableFilterDropdown.tsx
@@ -1,0 +1,80 @@
+import { Button, Input, Space } from '@oceanbase/design';
+import type { FilterDropdownProps } from '@oceanbase/design/es/table/interface';
+import { useEffect, useState } from 'react';
+
+export interface TableFilterDropdownProps extends FilterDropdownProps {
+  /* 确定筛选后的回调函数 */
+  onConfirm?: (value: React.Key) => void;
+}
+
+const TableFilterDropdown: React.FC<TableFilterDropdownProps> = ({
+  setSelectedKeys,
+  selectedKeys,
+  confirm,
+  clearFilters,
+  visible,
+  onConfirm,
+}) => {
+  const [value, setValue] = useState('');
+
+  const confirmFilter = () => {
+    confirm();
+    if (onConfirm) {
+      onConfirm(selectedKeys && selectedKeys[0]);
+    }
+  };
+
+  useEffect(() => {
+    if (!visible) {
+      confirmFilter();
+    }
+  }, [visible]);
+
+  return (
+    <div
+      style={{ padding: 8 }}
+      onBlur={() => {
+        confirmFilter();
+      }}
+    >
+      <Input
+        onChange={(e) => {
+          setValue(e.target.value);
+          setSelectedKeys(e.target.value ? [e.target.value] : []);
+        }}
+        value={value}
+        onPressEnter={() => {
+          confirmFilter();
+        }}
+        style={{ width: 188, marginBottom: 8, display: 'block' }}
+      />
+      <Space>
+        <Button
+          type="primary"
+          onClick={() => {
+            confirmFilter();
+          }}
+          size="small"
+          style={{ width: 90 }}
+        >
+          搜索
+        </Button>
+        <Button
+          onClick={() => {
+            if (clearFilters) {
+              clearFilters();
+              setValue('');
+            }
+            confirmFilter();
+          }}
+          size="small"
+          style={{ width: 90 }}
+        >
+          重置
+        </Button>
+      </Space>
+    </div>
+  );
+};
+
+export default TableFilterDropdown;

--- a/ui/src/pages/Cluster/Detail/Overview/index.tsx
+++ b/ui/src/pages/Cluster/Detail/Overview/index.tsx
@@ -35,7 +35,7 @@ import { useRequest } from 'ahooks';
 import { isEmpty } from 'lodash';
 import BasicInfo from './BasicInfo';
 import NFSInfoModal from './NFSInfoModal';
-import ParametersModal from './ParametersModal';
+// import ParametersModal from './ParametersModal';
 import ResourceDrawer from './ResourceDrawer';
 import ServerTable from './ServerTable';
 import ZoneTable from './ZoneTable';
@@ -46,8 +46,8 @@ const ClusterOverview: React.FC = () => {
   const [form] = Form.useForm();
   const [operateModalVisible, setOperateModalVisible] =
     useState<boolean>(false);
-  const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(false);
-  const [parametersRecord, setParametersRecord] = useState({});
+  // const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(false);
+  // const [parametersRecord, setParametersRecord] = useState({});
   const [resourceDrawerOpen, setResourceDrawerOpen] = useState<boolean>(false);
   const { ns, name } = useParams();
   const chooseZoneName = useRef<string>('');
@@ -492,20 +492,20 @@ const ClusterOverview: React.FC = () => {
           'max_syslog_file_count',
         ];
 
-        const valueContent =
-          parameters?.find((item) => item.name === record.name)?.value ||
-          record?.value;
+        // const valueContent =
+        //   parameters?.find((item) => item.name === record.name)?.value ||
+        //   record?.value;
 
         return (
           <Space size={1}>
             <Button
               type="link"
               onClick={() => {
-                setIsDrawerOpen(true);
-                setParametersRecord({
-                  key: record.name,
-                  value: valueContent,
-                });
+                // setIsDrawerOpen(true);
+                // setParametersRecord({
+                //   key: record.name,
+                //   value: valueContent,
+                // });
               }}
             >
               {intl.formatMessage({
@@ -855,7 +855,7 @@ const ClusterOverview: React.FC = () => {
         }}
       />
 
-      <ParametersModal
+      {/* <ParametersModal
         visible={isDrawerOpen}
         onCancel={() => setIsDrawerOpen(false)}
         onSuccess={() => {
@@ -871,7 +871,7 @@ const ClusterOverview: React.FC = () => {
         }}
         initialValues={parametersRecord}
         {...(clusterDetail?.info as API.ClusterInfo)}
-      />
+      /> */}
 
       <ResourceDrawer
         visible={resourceDrawerOpen}

--- a/ui/src/pages/Cluster/Detail/Overview/index.tsx
+++ b/ui/src/pages/Cluster/Detail/Overview/index.tsx
@@ -5,22 +5,15 @@ import {
   Col,
   Descriptions,
   Dropdown,
-  Form,
-  Input,
   MenuProps,
   Row,
-  Select,
   Space,
-  Table,
-  Tag,
   Tooltip,
   message,
 } from 'antd';
 import { useEffect, useRef, useState } from 'react';
 
-import { obcluster } from '@/api';
 import EventsTable from '@/components/EventsTable';
-import IconTip from '@/components/IconTip';
 import OperateModal from '@/components/customModal/OperateModal';
 import showDeleteConfirm from '@/components/customModal/showDeleteConfirm';
 import { REFRESH_CLUSTER_TIME } from '@/constants';
@@ -35,7 +28,6 @@ import { useRequest } from 'ahooks';
 import { isEmpty } from 'lodash';
 import BasicInfo from './BasicInfo';
 import NFSInfoModal from './NFSInfoModal';
-// import ParametersModal from './ParametersModal';
 import ResourceDrawer from './ResourceDrawer';
 import ServerTable from './ServerTable';
 import ZoneTable from './ZoneTable';
@@ -43,11 +35,8 @@ import ZoneTable from './ZoneTable';
 const ClusterOverview: React.FC = () => {
   const { setChooseClusterName } = useModel('global');
   const access = useAccess();
-  const [form] = Form.useForm();
   const [operateModalVisible, setOperateModalVisible] =
     useState<boolean>(false);
-  // const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(false);
-  // const [parametersRecord, setParametersRecord] = useState({});
   const [resourceDrawerOpen, setResourceDrawerOpen] = useState<boolean>(false);
   const { ns, name } = useParams();
   const chooseZoneName = useRef<string>('');
@@ -56,30 +45,6 @@ const ClusterOverview: React.FC = () => {
   const [mountNFSModal, setMountNFSModal] = useState<boolean>(false);
   const [removeNFSModal, setRemoveNFSModal] = useState<boolean>(false);
   const modalType = useRef<API.ModalType>('addZone');
-  const [parametersData, setParametersData] = useState([]);
-
-  const { setFieldsValue, validateFields } = form;
-
-  const getNewData = (data) => {
-    const obt = data?.map((element: any) => {
-      // 在 obcluster 的 parameters  里面的就是托管给 operator
-      const findName = parameters?.find(
-        (item: any) => element.name === item.name,
-      );
-
-      if (!isEmpty(findName)) {
-        return {
-          ...element,
-          controlParameter: true,
-          accordance: findName?.value === findName?.specValue,
-        };
-      } else if (isEmpty(findName)) {
-        return { ...element, controlParameter: false, accordance: undefined };
-      }
-    });
-
-    return obt;
-  };
 
   const {
     data: clusterDetail,
@@ -93,48 +58,12 @@ const ClusterOverview: React.FC = () => {
       if (data.status === 'operating') {
         timerRef.current = setTimeout(() => {
           getClusterDetail({ ns: ns!, name: name! });
-          refresh();
         }, REFRESH_CLUSTER_TIME);
       } else if (timerRef.current) {
         clearTimeout(timerRef.current);
       }
     },
   });
-
-  const {
-    data: listOBClusterParameters,
-    loading,
-    refresh,
-  } = useRequest(obcluster.listOBClusterParameters, {
-    defaultParams: [ns, name],
-    refreshDeps: [clusterDetail?.status],
-    onSuccess: (res) => {
-      const newData = getNewData(res?.data);
-      setParametersData(newData);
-    },
-  });
-
-  const { runAsync: patchOBCluster, loading: patchOBClusterloading } =
-    useRequest(obcluster.patchOBCluster, {
-      manual: true,
-      onSuccess: (res) => {
-        if (res.successful) {
-          message.success(
-            intl.formatMessage({
-              id: 'src.pages.Cluster.Detail.Overview.FF85D01F',
-              defaultMessage: '解除托管已成功',
-            }),
-          );
-          setFieldsValue({
-            name: undefined,
-            controlParameter: undefined,
-            accordance: undefined,
-          });
-          refresh();
-          clusterDetailRefresh();
-        }
-      },
-    });
 
   const handleDelete = async () => {
     const res = await deleteClusterReportWrap({ ns: ns!, name: name! });
@@ -164,7 +93,6 @@ const ClusterOverview: React.FC = () => {
   };
 
   const {
-    parameters,
     storage,
     resource,
     deletionProtection,
@@ -329,50 +257,6 @@ const ClusterOverview: React.FC = () => {
     },
   ];
 
-  const controlParameters = [
-    {
-      label: intl.formatMessage({
-        id: 'src.pages.Cluster.Detail.Overview.403B7E1C',
-        defaultMessage: '已托管',
-      }),
-      value: true,
-    },
-    {
-      label: intl.formatMessage({
-        id: 'src.pages.Cluster.Detail.Overview.46B66B3E',
-        defaultMessage: '未托管',
-      }),
-      value: false,
-    },
-  ];
-
-  const accordanceList = [
-    {
-      label: (
-        <Tag color={'green'}>
-          {intl.formatMessage({
-            id: 'src.pages.Cluster.Detail.Overview.D5CCD27D',
-            defaultMessage: '已匹配',
-          })}
-        </Tag>
-      ),
-
-      value: true,
-    },
-    {
-      label: (
-        <Tag color={'gold'}>
-          {intl.formatMessage({
-            id: 'src.pages.Cluster.Detail.Overview.DF83C06D',
-            defaultMessage: '不匹配',
-          })}
-        </Tag>
-      ),
-
-      value: false,
-    },
-  ];
-
   useEffect(() => {
     getClusterDetail({ ns: ns!, name: name! });
 
@@ -382,159 +266,6 @@ const ClusterOverview: React.FC = () => {
       }
     };
   }, []);
-
-  const columns = [
-    {
-      title: intl.formatMessage({
-        id: 'src.pages.Cluster.Detail.Overview.E5342F26',
-        defaultMessage: '参数名',
-      }),
-      dataIndex: 'name',
-    },
-    {
-      title: intl.formatMessage({
-        id: 'src.pages.Cluster.Detail.Overview.FA0D096B',
-        defaultMessage: '参数值',
-      }),
-      dataIndex: 'value',
-      render: (text: string, record) => {
-        const content =
-          parameters?.find((item) => item.name === record.name)?.value || text;
-
-        return <span>{content}</span>;
-      },
-    },
-    {
-      title: intl.formatMessage({
-        id: 'src.pages.Cluster.Detail.Overview.93A9D19D',
-        defaultMessage: '参数说明',
-      }),
-      dataIndex: 'info',
-    },
-    {
-      title: intl.formatMessage({
-        id: 'src.pages.Cluster.Detail.Overview.4FCF90AF',
-        defaultMessage: '托管 operator',
-      }),
-      width: 140,
-      dataIndex: 'controlParameter',
-      filters: controlParameters.map(({ label, value }) => ({
-        text: label,
-        value,
-      })),
-      onFilter: (value: any, record) => {
-        return record?.controlParameter === value;
-      },
-      render: (text: boolean) => {
-        return (
-          <span>
-            {text
-              ? intl.formatMessage({
-                  id: 'src.pages.Cluster.Detail.Overview.319FA0DB',
-                  defaultMessage: '是',
-                })
-              : intl.formatMessage({
-                  id: 'src.pages.Cluster.Detail.Overview.5DD958C7',
-                  defaultMessage: '否',
-                })}
-          </span>
-        );
-      },
-    },
-    {
-      title: (
-        <IconTip
-          tip={intl.formatMessage({
-            id: 'src.pages.Cluster.Detail.Overview.0B4A3E74',
-            defaultMessage: '只有托管 operator 的参数才有状态',
-          })}
-          content={intl.formatMessage({
-            id: 'src.pages.Cluster.Detail.Overview.6AD01A82',
-            defaultMessage: '状态',
-          })}
-        />
-      ),
-
-      dataIndex: 'accordance',
-      width: 100,
-      render: (text) => {
-        const tagColor = text ? 'green' : 'gold';
-        const tagContent = text
-          ? intl.formatMessage({
-              id: 'src.pages.Cluster.Detail.Overview.9A3A4407',
-              defaultMessage: '已匹配',
-            })
-          : intl.formatMessage({
-              id: 'src.pages.Cluster.Detail.Overview.D6588C55',
-              defaultMessage: '不匹配',
-            });
-
-        return text === undefined ? (
-          '/'
-        ) : (
-          <Tag color={tagColor}>{tagContent}</Tag>
-        );
-      },
-    },
-    {
-      title: intl.formatMessage({
-        id: 'src.pages.Cluster.Detail.Overview.1B9EA477',
-        defaultMessage: '操作',
-      }),
-      dataIndex: 'controlParameter',
-      align: 'center',
-      render: (text, record) => {
-        const disableUnescrow = [
-          'memory_limit',
-          'datafile_maxsize',
-          'datafile_next',
-          'enable_syslog_recycle',
-          'max_syslog_file_count',
-        ];
-
-        // const valueContent =
-        //   parameters?.find((item) => item.name === record.name)?.value ||
-        //   record?.value;
-
-        return (
-          <Space size={1}>
-            <Button
-              type="link"
-              onClick={() => {
-                // setIsDrawerOpen(true);
-                // setParametersRecord({
-                //   key: record.name,
-                //   value: valueContent,
-                // });
-              }}
-            >
-              {intl.formatMessage({
-                id: 'src.pages.Cluster.Detail.Overview.F5A088FB',
-                defaultMessage: '编辑',
-              })}
-            </Button>
-            {text && (
-              <Button
-                type="link"
-                disabled={disableUnescrow.some((item) => item === record.name)}
-                loading={patchOBClusterloading}
-                onClick={() => {
-                  patchOBCluster(ns, name, {
-                    deletedParameters: [record.name],
-                  });
-                }}
-              >
-                {intl.formatMessage({
-                  id: 'src.pages.Cluster.Detail.Overview.5FACF7C0',
-                  defaultMessage: '解除托管',
-                })}
-              </Button>
-            )}
-          </Space>
-        );
-      },
-    },
-  ];
 
   return (
     <PageContainer header={header()} loading={clusterDetailLoading}>
@@ -624,201 +355,7 @@ const ClusterOverview: React.FC = () => {
             </Descriptions>
           </Card>
         </Col>
-        <Col span={24}>
-          <Card
-            title={
-              <h2 style={{ marginBottom: 0 }}>
-                {intl.formatMessage({
-                  id: 'src.pages.Cluster.Detail.Overview.BFE7CA02',
-                  defaultMessage: '集群参数设置',
-                })}
-              </h2>
-            }
-          >
-            <Form form={form}>
-              <Row gutter={[24, 16]}>
-                <Col span={6}>
-                  <Form.Item
-                    label={intl.formatMessage({
-                      id: 'src.pages.Cluster.Detail.Overview.BF489BCE',
-                      defaultMessage: '参数名',
-                    })}
-                    name={'name'}
-                  >
-                    <Input
-                      placeholder={intl.formatMessage({
-                        id: 'src.pages.Cluster.Detail.Overview.E5E4E6B5',
-                        defaultMessage: '请输入',
-                      })}
-                      allowClear
-                    />
-                  </Form.Item>
-                </Col>
-                <Col span={6}>
-                  <Form.Item
-                    label={intl.formatMessage({
-                      id: 'src.pages.Cluster.Detail.Overview.4F7F81B0',
-                      defaultMessage: '托管状态',
-                    })}
-                    name={'controlParameter'}
-                  >
-                    <Select
-                      options={controlParameters}
-                      allowClear={true}
-                      placeholder={intl.formatMessage({
-                        id: 'src.pages.Cluster.Detail.Overview.A89209B9',
-                        defaultMessage: '请选择',
-                      })}
-                    />
-                  </Form.Item>
-                </Col>
-                <Col span={6}>
-                  <Form.Item
-                    label={intl.formatMessage({
-                      id: 'src.pages.Cluster.Detail.Overview.2873685C',
-                      defaultMessage: '状态',
-                    })}
-                    name={'accordance'}
-                  >
-                    <Select
-                      options={accordanceList}
-                      allowClear={true}
-                      placeholder={intl.formatMessage({
-                        id: 'src.pages.Cluster.Detail.Overview.5C55A022',
-                        defaultMessage: '请选择',
-                      })}
-                    />
-                  </Form.Item>
-                </Col>
-                <Col>
-                  <Space size="middle">
-                    <Button
-                      type="primary"
-                      onClick={() => {
-                        validateFields().then((values) => {
-                          const { name, controlParameter, accordance } = values;
-                          const newParametersData = getNewData(
-                            listOBClusterParameters?.data,
-                          );
 
-                          if (name !== undefined) {
-                            setParametersData(
-                              newParametersData?.filter((item) =>
-                                item.name?.includes(name.trim()),
-                              ),
-                            );
-                          }
-                          if (controlParameter !== undefined) {
-                            setParametersData(
-                              newParametersData?.filter(
-                                (item) =>
-                                  item.controlParameter === controlParameter,
-                              ),
-                            );
-                          }
-                          // 已托管的参数才有托管状态
-                          const controlParameterContent =
-                            newParametersData?.filter(
-                              (item) => item.controlParameter === true,
-                            );
-                          if (accordance !== undefined) {
-                            setParametersData(
-                              controlParameterContent?.filter(
-                                (item) => item.accordance === accordance,
-                              ),
-                            );
-                          }
-                          if (
-                            name !== undefined &&
-                            controlParameter !== undefined
-                          ) {
-                            setParametersData(
-                              newParametersData?.filter(
-                                (item) =>
-                                  item.name?.includes(name.trim()) &&
-                                  item.controlParameter === controlParameter,
-                              ),
-                            );
-                          }
-                          if (name !== undefined && accordance !== undefined) {
-                            setParametersData(
-                              controlParameterContent?.filter(
-                                (item) =>
-                                  item.name?.includes(name.trim()) &&
-                                  item.accordance === accordance,
-                              ),
-                            );
-                          }
-                          if (
-                            controlParameter !== undefined &&
-                            accordance !== undefined
-                          ) {
-                            if (controlParameter === true) {
-                              setParametersData(
-                                controlParameterContent?.filter(
-                                  (item) => item.accordance === accordance,
-                                ),
-                              );
-                            } else {
-                              setParametersData([]);
-                            }
-                          }
-
-                          if (
-                            name !== undefined &&
-                            controlParameter !== undefined &&
-                            accordance !== undefined
-                          ) {
-                            if (controlParameter === true) {
-                              setParametersData(
-                                controlParameterContent?.filter(
-                                  (item) =>
-                                    item.name?.includes(name.trim()) &&
-                                    item.accordance === accordance,
-                                ),
-                              );
-                            } else {
-                              // 未托管的，没有状态，因此为空
-                              setParametersData([]);
-                            }
-                          }
-                        });
-                      }}
-                    >
-                      {intl.formatMessage({
-                        id: 'src.pages.Cluster.Detail.Overview.E3D520F9',
-                        defaultMessage: '查询',
-                      })}
-                    </Button>
-                    <Button
-                      onClick={() => {
-                        setFieldsValue({
-                          name: undefined,
-                          controlParameter: undefined,
-                          accordance: undefined,
-                        });
-                        refresh();
-                      }}
-                    >
-                      {intl.formatMessage({
-                        id: 'src.pages.Cluster.Detail.Overview.96EEA6EE',
-                        defaultMessage: '重置',
-                      })}
-                    </Button>
-                  </Space>
-                </Col>
-              </Row>
-            </Form>
-
-            <Table
-              rowKey="name"
-              pagination={{ simple: true }}
-              columns={columns}
-              loading={loading}
-              dataSource={parametersData}
-            />
-          </Card>
-        </Col>
         {clusterDetail && (
           <ZoneTable
             clusterStatus={clusterDetail.status}
@@ -854,24 +391,6 @@ const ClusterOverview: React.FC = () => {
           defaultValue: chooseServerNum,
         }}
       />
-
-      {/* <ParametersModal
-        visible={isDrawerOpen}
-        onCancel={() => setIsDrawerOpen(false)}
-        onSuccess={() => {
-          setIsDrawerOpen(false);
-          clusterDetailRefresh();
-          // 编辑成功后，清空搜索条件，刷新参数列表
-          setFieldsValue({
-            name: undefined,
-            controlParameter: undefined,
-            accordance: undefined,
-          });
-          refresh();
-        }}
-        initialValues={parametersRecord}
-        {...(clusterDetail?.info as API.ClusterInfo)}
-      /> */}
 
       <ResourceDrawer
         visible={resourceDrawerOpen}

--- a/ui/src/pages/Cluster/Detail/Parameters/ParametersModal.tsx
+++ b/ui/src/pages/Cluster/Detail/Parameters/ParametersModal.tsx
@@ -2,7 +2,7 @@ import { obcluster } from '@/api';
 import { intl } from '@/utils/intl';
 import { useRequest } from 'ahooks';
 import { Button, Col, Form, Input, message, Modal, Row, Space } from 'antd';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 export interface ParametersModalProps {
   visible: boolean;
@@ -41,6 +41,15 @@ const ParametersModal: React.FC<ParametersModalProps> = ({
       },
     },
   );
+
+  useEffect(() => {
+    if (visible) {
+      form.setFieldsValue({
+        key: initialValues?.name,
+        value: initialValues?.value,
+      });
+    }
+  }, [initialValues, visible]);
 
   return (
     <Modal
@@ -104,7 +113,6 @@ const ParametersModal: React.FC<ParametersModalProps> = ({
                 id: 'src.pages.Cluster.Detail.Overview.0F9AD89D',
                 defaultMessage: '参数名',
               })}
-              initialValue={initialValues?.name}
               name={'key'}
             >
               <Input disabled={true} />
@@ -117,7 +125,6 @@ const ParametersModal: React.FC<ParametersModalProps> = ({
                 defaultMessage: '参数值',
               })}
               name={'value'}
-              initialValue={initialValues?.value}
               rules={[
                 {
                   required: true,

--- a/ui/src/pages/Cluster/Detail/Parameters/ParametersModal.tsx
+++ b/ui/src/pages/Cluster/Detail/Parameters/ParametersModal.tsx
@@ -2,18 +2,13 @@ import { obcluster } from '@/api';
 import { intl } from '@/utils/intl';
 import { useRequest } from 'ahooks';
 import { Button, Col, Form, Input, message, Modal, Row, Space } from 'antd';
-import React, { useEffect } from 'react';
-
-interface kvPair {
-  key: string;
-  value: string;
-}
+import React from 'react';
 
 export interface ParametersModalProps {
   visible: boolean;
   onCancel: () => void;
   onSuccess: () => void;
-  initialValues: kvPair;
+  initialValues: any[];
   name: string;
   namespace: string;
 }
@@ -26,14 +21,8 @@ const ParametersModal: React.FC<ParametersModalProps> = ({
   name,
   namespace,
 }) => {
-  const [form] = Form.useForm<kvPair>();
+  const [form] = Form.useForm<API.CreateClusterData>();
   const { validateFields, resetFields } = form;
-
-  useEffect(() => {
-    if (visible) {
-      form.setFieldsValue(initialValues);
-    }
-  }, [visible]);
 
   const { runAsync: updateParameters, loading } = useRequest(
     obcluster.patchOBCluster,
@@ -59,10 +48,11 @@ const ParametersModal: React.FC<ParametersModalProps> = ({
         id: 'src.pages.Cluster.Detail.Overview.849E8956',
         defaultMessage: '参数编辑',
       })}
-      maskClosable={false}
       open={visible}
+      destroyOnClose
       onCancel={() => {
         onCancel();
+        resetFields();
       }}
       width={520}
       footer={
@@ -114,6 +104,7 @@ const ParametersModal: React.FC<ParametersModalProps> = ({
                 id: 'src.pages.Cluster.Detail.Overview.0F9AD89D',
                 defaultMessage: '参数名',
               })}
+              initialValue={initialValues?.name}
               name={'key'}
             >
               <Input disabled={true} />
@@ -126,6 +117,7 @@ const ParametersModal: React.FC<ParametersModalProps> = ({
                 defaultMessage: '参数值',
               })}
               name={'value'}
+              initialValue={initialValues?.value}
               rules={[
                 {
                   required: true,

--- a/ui/src/pages/Cluster/Detail/Parameters/index.tsx
+++ b/ui/src/pages/Cluster/Detail/Parameters/index.tsx
@@ -1,0 +1,336 @@
+import { obcluster } from '@/api';
+import IconTip from '@/components/IconTip';
+import { getClusterDetailReq } from '@/services';
+import { getColumnSearchProps } from '@/utils/component';
+import { intl } from '@/utils/intl';
+import { PageContainer } from '@ant-design/pro-components';
+import { useParams } from '@umijs/max';
+import { useRequest } from 'ahooks';
+import { Button, Card, Col, message, Row, Space, Table, Tag } from 'antd';
+import { isEmpty } from 'lodash';
+import { useState } from 'react';
+import ParametersModal from './ParametersModal';
+
+export default function Parameters() {
+  const { ns, name } = useParams();
+
+  const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(false);
+  const [parametersRecord, setParametersRecord] = useState({});
+
+  const { runAsync: patchOBCluster, loading: patchOBClusterloading } =
+    useRequest(obcluster.patchOBCluster, {
+      manual: true,
+      onSuccess: (res) => {
+        if (res.successful) {
+          message.success(
+            intl.formatMessage({
+              id: 'src.pages.Cluster.Detail.Overview.FF85D01F',
+              defaultMessage: '解除托管已成功',
+            }),
+          );
+          //   setFieldsValue({
+          //     name: undefined,
+          //     controlParameter: undefined,
+          //     accordance: undefined,
+          //   });
+          refresh();
+        }
+      },
+    });
+
+  const { data: clusterDetail, refresh: clusterDetailRefresh } = useRequest(
+    getClusterDetailReq,
+    {},
+  );
+
+  const {
+    data: listOBClusterParameters,
+    loading,
+    refresh,
+  } = useRequest(obcluster.listOBClusterParameters, {
+    defaultParams: [ns, name],
+    refreshDeps: [clusterDetail?.status],
+  });
+
+  const parameters = clusterDetail?.info?.parameters;
+  const getNewData = (data) => {
+    const obt = data?.map((element: any) => {
+      // 在 obcluster 的 parameters  里面的就是托管给 operator
+      const findName = parameters?.find(
+        (item: any) => element.name === item.name,
+      );
+
+      if (!isEmpty(findName)) {
+        return {
+          ...element,
+          controlParameter: true,
+          accordance: findName?.value === findName?.specValue,
+        };
+      } else if (isEmpty(findName)) {
+        return { ...element, controlParameter: false, accordance: 'null' };
+      }
+    });
+
+    return obt;
+  };
+
+  const parametersData = getNewData(listOBClusterParameters?.data);
+  const controlParameters = [
+    {
+      label: intl.formatMessage({
+        id: 'src.pages.Cluster.Detail.Overview.403B7E1C',
+        defaultMessage: '已托管',
+      }),
+      value: true,
+    },
+    {
+      label: intl.formatMessage({
+        id: 'src.pages.Cluster.Detail.Overview.46B66B3E',
+        defaultMessage: '未托管',
+      }),
+      value: false,
+    },
+  ];
+
+  const accordanceList = [
+    {
+      label: (
+        <Tag color={'green'}>
+          {intl.formatMessage({
+            id: 'src.pages.Cluster.Detail.Overview.D5CCD27D',
+            defaultMessage: '已匹配',
+          })}
+        </Tag>
+      ),
+
+      value: true,
+    },
+    {
+      label: (
+        <Tag color={'gold'}>
+          {intl.formatMessage({
+            id: 'src.pages.Cluster.Detail.Overview.DF83C06D',
+            defaultMessage: '不匹配',
+          })}
+        </Tag>
+      ),
+
+      value: false,
+    },
+    {
+      label: '/',
+
+      value: 'null',
+    },
+  ];
+
+  const columns = [
+    {
+      title: intl.formatMessage({
+        id: 'src.pages.Cluster.Detail.Overview.E5342F26',
+        defaultMessage: '参数名',
+      }),
+      dataIndex: 'name',
+      ...getColumnSearchProps({
+        frontEndSearch: true,
+        dataIndex: 'name',
+      }),
+    },
+    {
+      title: intl.formatMessage({
+        id: 'src.pages.Cluster.Detail.Overview.FA0D096B',
+        defaultMessage: '参数值',
+      }),
+      dataIndex: 'value',
+      render: (text: string, record) => {
+        const content =
+          parameters?.find((item) => item.name === record.name)?.value || text;
+
+        return <span>{content}</span>;
+      },
+    },
+    {
+      title: intl.formatMessage({
+        id: 'src.pages.Cluster.Detail.Overview.93A9D19D',
+        defaultMessage: '参数说明',
+      }),
+      dataIndex: 'info',
+    },
+    {
+      title: intl.formatMessage({
+        id: 'src.pages.Cluster.Detail.Overview.4FCF90AF',
+        defaultMessage: '托管 operator',
+      }),
+      width: 140,
+      dataIndex: 'controlParameter',
+      filters: controlParameters.map(({ label, value }) => ({
+        text: label,
+        value,
+      })),
+      onFilter: (value: any, record) => {
+        return record?.controlParameter === value;
+      },
+      render: (text: boolean) => {
+        return (
+          <span>
+            {text
+              ? intl.formatMessage({
+                  id: 'src.pages.Cluster.Detail.Overview.319FA0DB',
+                  defaultMessage: '是',
+                })
+              : intl.formatMessage({
+                  id: 'src.pages.Cluster.Detail.Overview.5DD958C7',
+                  defaultMessage: '否',
+                })}
+          </span>
+        );
+      },
+    },
+    {
+      title: (
+        <IconTip
+          tip={intl.formatMessage({
+            id: 'src.pages.Cluster.Detail.Overview.0B4A3E74',
+            defaultMessage: '只有托管 operator 的参数才有状态',
+          })}
+          content={intl.formatMessage({
+            id: 'src.pages.Cluster.Detail.Overview.6AD01A82',
+            defaultMessage: '状态',
+          })}
+        />
+      ),
+
+      dataIndex: 'accordance',
+      width: 100,
+      filters: accordanceList.map(({ label, value }) => ({
+        text: label,
+        value,
+      })),
+      onFilter: (value: any, record) => {
+        return record?.accordance === value;
+      },
+      render: (text) => {
+        const tagColor = text ? 'green' : 'gold';
+        const tagContent = text
+          ? intl.formatMessage({
+              id: 'src.pages.Cluster.Detail.Overview.9A3A4407',
+              defaultMessage: '已匹配',
+            })
+          : intl.formatMessage({
+              id: 'src.pages.Cluster.Detail.Overview.D6588C55',
+              defaultMessage: '不匹配',
+            });
+
+        return text === 'null' ? '/' : <Tag color={tagColor}>{tagContent}</Tag>;
+      },
+    },
+    {
+      title: intl.formatMessage({
+        id: 'src.pages.Cluster.Detail.Overview.1B9EA477',
+        defaultMessage: '操作',
+      }),
+      dataIndex: 'controlParameter',
+      align: 'center',
+      render: (text, record) => {
+        const disableUnescrow = [
+          'memory_limit',
+          'datafile_maxsize',
+          'datafile_next',
+          'enable_syslog_recycle',
+          'max_syslog_file_count',
+        ];
+
+        const valueContent =
+          parameters?.find((item) => item.name === record.name)?.value ||
+          record?.value;
+
+        return (
+          <Space size={1}>
+            <Button
+              type="link"
+              onClick={() => {
+                setIsDrawerOpen(true);
+                setParametersRecord({
+                  ...record,
+                  value: valueContent,
+                });
+              }}
+            >
+              {intl.formatMessage({
+                id: 'src.pages.Cluster.Detail.Overview.F5A088FB',
+                defaultMessage: '编辑',
+              })}
+            </Button>
+            {text && (
+              <Button
+                type="link"
+                disabled={disableUnescrow.some((item) => item === record.name)}
+                loading={patchOBClusterloading}
+                onClick={() => {
+                  patchOBCluster(ns, name, {
+                    deletedParameters: [record.name],
+                  });
+                }}
+              >
+                {intl.formatMessage({
+                  id: 'src.pages.Cluster.Detail.Overview.5FACF7C0',
+                  defaultMessage: '解除托管',
+                })}
+              </Button>
+            )}
+          </Space>
+        );
+      },
+    },
+  ];
+
+  return (
+    <PageContainer
+      header={{
+        title: '集群参数',
+      }}
+    >
+      <Row>
+        <Col span={24}>
+          <Card
+            title={
+              <h2 style={{ marginBottom: 0 }}>
+                {intl.formatMessage({
+                  id: 'src.pages.Cluster.Detail.Overview.BFE7CA02',
+                  defaultMessage: '集群参数设置',
+                })}
+              </h2>
+            }
+          >
+            <Table
+              rowKey="name"
+              pagination={{ simple: true }}
+              columns={columns}
+              loading={loading}
+              dataSource={parametersData}
+            />
+          </Card>
+        </Col>
+      </Row>
+      <ParametersModal
+        visible={isDrawerOpen}
+        onCancel={() => setIsDrawerOpen(false)}
+        onSuccess={() => {
+          setIsDrawerOpen(false);
+          clusterDetailRefresh();
+          // 编辑成功后，清空搜索条件，刷新参数列表
+          //   setFieldsValue({
+          //     name: undefined,
+          //     controlParameter: undefined,
+          //     accordance: undefined,
+          //   });
+          refresh();
+        }}
+        initialValues={parametersRecord}
+        name={name}
+        namespace={ns}
+        // {...(clusterDetail?.info as API.ClusterInfo)}
+      />
+    </PageContainer>
+  );
+}

--- a/ui/src/pages/Cluster/Detail/Parameters/index.tsx
+++ b/ui/src/pages/Cluster/Detail/Parameters/index.tsx
@@ -28,11 +28,7 @@ export default function Parameters() {
               defaultMessage: '解除托管已成功',
             }),
           );
-          //   setFieldsValue({
-          //     name: undefined,
-          //     controlParameter: undefined,
-          //     accordance: undefined,
-          //   });
+
           refresh();
         }
       },
@@ -318,12 +314,6 @@ export default function Parameters() {
         onSuccess={() => {
           setIsDrawerOpen(false);
           clusterDetailRefresh();
-          // 编辑成功后，清空搜索条件，刷新参数列表
-          //   setFieldsValue({
-          //     name: undefined,
-          //     controlParameter: undefined,
-          //     accordance: undefined,
-          //   });
           refresh();
         }}
         initialValues={parametersRecord}

--- a/ui/src/pages/Cluster/Detail/index.tsx
+++ b/ui/src/pages/Cluster/Detail/index.tsx
@@ -39,6 +39,12 @@ export default () => {
       link: `/cluster/${ns}/${name}/${clusterName}/tenant`,
     },
     {
+      title: '集群参数',
+      key: 'parameters',
+      link: `/cluster/${ns}/${name}/${clusterName}/parameters`,
+      accessible: access.obclusterwrite,
+    },
+    {
       title: intl.formatMessage({
         id: 'Dashboard.Cluster.Detail.Connection1',
         defaultMessage: '连接集群',

--- a/ui/src/utils/component.tsx
+++ b/ui/src/utils/component.tsx
@@ -1,0 +1,36 @@
+import TableFilterDropdown from '@/components/TableFilterDropdown';
+import { SearchOutlined } from '@ant-design/icons';
+import { token } from '@oceanbase/design';
+import type { FilterDropdownProps } from '@oceanbase/design/es/table/interface';
+
+export const getColumnSearchProps = ({
+  frontEndSearch,
+  dataIndex,
+  onConfirm,
+}: {
+  frontEndSearch: boolean; // 前端分页时，dataIndex 必传，该参数对后端分页无效
+  dataIndex?: string;
+  onConfirm?: (value?: React.Key) => void;
+}) => ({
+  filterDropdown: (props: FilterDropdownProps) => (
+    <TableFilterDropdown {...props} onConfirm={onConfirm} />
+  ),
+
+  filterIcon: (filtered: boolean) => (
+    <SearchOutlined
+      style={{ color: filtered ? token.colorPrimary : undefined }}
+    />
+  ),
+
+  // 前端搜索，需要定义 onFilter 函数
+  ...(frontEndSearch
+    ? {
+        onFilter: (value, record) =>
+          record[dataIndex] &&
+          record[dataIndex]
+            .toString()
+            .toLowerCase()
+            .includes(value && value.toLowerCase()),
+      }
+    : {}),
+});


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
新增内容如下：

1. 新增集群参数页导航栏
2. 迁移原有的集群参数列表
3. 集群参数列表名称列头，增加搜索功能，支持模糊匹配搜索
4. 扩展 getColumnSearchProps 组件，便于后期类似需求实用
5. 集群参数状态增加筛选功能，在原基础上增加未有状态的筛选项
6. 删除集群概览页上原有的参数 UI 及功能逻辑

<img width="1434" alt="image" src="https://github.com/user-attachments/assets/6ec6131d-6591-4307-833f-6c6bf4ebcade" />
<img width="1214" alt="image" src="https://github.com/user-attachments/assets/00ecb62b-40e2-4248-a3a4-ef6e38489174" />
<img width="1202" alt="image" src="https://github.com/user-attachments/assets/99cc9a35-978b-4a12-a4d7-0c683501e07c" />
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/a2a3cee8-282e-4a5d-8dca-e98be6c85643" />
<img width="623" alt="image" src="https://github.com/user-attachments/assets/25b2b7fa-45a1-448a-a06f-204ee001cd2c" />


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
