### PR TITLE
feat： 新建集群页， proxyroPassword 相关功能联调

### DIFF
--- a/ui/src/components/PasswordInput/index.tsx
+++ b/ui/src/components/PasswordInput/index.tsx
@@ -40,8 +40,8 @@ export default function PasswordInput({
   const genaretaPassword = () => {
     const password = generateRandomPassword();
     onChange(password);
-    setFieldValue('rootPassword', password);
-    form.validateFields(['rootPassword']);
+    setFieldValue(name, password);
+    form.validateFields([name]);
   };
   const passwordCopy = () => {
     if (value) {
@@ -96,7 +96,7 @@ export default function PasswordInput({
             defaultMessage: '密码',
           })
         }
-        name="rootPassword"
+        name={name}
         rules={passwordRules}
         className={styles.passwordFormItem}
         validateFirst

--- a/ui/src/pages/Cluster/New/index.tsx
+++ b/ui/src/pages/Cluster/New/index.tsx
@@ -50,6 +50,9 @@ export default function New() {
   const onFinish = async (values: API.CreateClusterData) => {
     values.clusterId = new Date().getTime() % 4294901759;
     values.rootPassword = encryptText(values.rootPassword, publicKey) as string;
+    values.proxyroPassword = values.proxyroPassword
+      ? (encryptText(values.proxyroPassword, publicKey) as string)
+      : undefined;
     values.deletionProtection = deleteValue;
     values.pvcIndependent = pvcValue;
 


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
原有的密码输入框，进行改造，便于适用多种密码框
页面新增告警设置交互：
箭头向下展示，proxyroPassword加密传输。
箭头朝右收起，proxyroPassword为undefined
 
<img width="1367" alt="image" src="https://github.com/user-attachments/assets/7c246caf-4ed2-4453-bb4b-73e3580a3343" />
<img width="1311" alt="image" src="https://github.com/user-attachments/assets/858235db-c122-4b00-9401-0916c24943eb" />
<img width="1422" alt="image" src="https://github.com/user-attachments/assets/220c3986-45d6-4ce4-8696-81eb20d3706d" />



## Solution Description
<!-- Please clearly and concisely describe your solution. -->
