### PR TITLE
improve：修复联调问题 || improve: Fix joint debugging problem

### DIFF
--- a/ui/src/components/CustomTooltip/index.tsx
+++ b/ui/src/components/CustomTooltip/index.tsx
@@ -3,12 +3,13 @@ import { Tooltip } from 'antd';
 export default function CustomTooltip({
   text,
   width,
+  tooltipTittle,
 }: {
   text: string;
   width: number;
 }) {
   return (
-    <Tooltip title={text}>
+    <Tooltip title={tooltipTittle || text}>
       <p
         style={{
           overflow: 'hidden',

--- a/ui/src/components/CustomTooltip/index.tsx
+++ b/ui/src/components/CustomTooltip/index.tsx
@@ -3,13 +3,13 @@ import { Tooltip } from 'antd';
 export default function CustomTooltip({
   text,
   width,
-  tooltipTittle,
+  tooltipTitle,
 }: {
   text: string;
   width: number;
 }) {
   return (
-    <Tooltip title={tooltipTittle || text}>
+    <Tooltip title={tooltipTitle || text}>
       <p
         style={{
           overflow: 'hidden',

--- a/ui/src/constants/node.ts
+++ b/ui/src/constants/node.ts
@@ -14,8 +14,8 @@ export const EFFECT_LIST = [
     label: 'NoSchedule',
   },
   {
-    value: 'PerferNoSchedule',
-    label: 'PerferNoSchedule',
+    value: 'PreferNoSchedule',
+    label: 'PreferNoSchedule',
   },
   {
     value: 'NoExecute',

--- a/ui/src/i18n/strings/zh-CN.json
+++ b/ui/src/i18n/strings/zh-CN.json
@@ -1224,7 +1224,7 @@
   "src.pages.Cluster.Detail.Overview.05F3B008": "存储资源",
   "src.pages.Cluster.Detail.Overview.F4D80804": "PVC 独立生命周期",
   "src.pages.Cluster.Detail.Overview.21732CE3": "只能在创建时指定，不支持修改",
-  "src.pages.Cluster.Detail.Overview.BFE7CA02": "集群参数设置",
+  "src.pages.Cluster.Detail.Overview.BFE7CA02": "集群参数",
   "src.pages.Cluster.Detail.Overview.BF489BCE": "参数名",
   "src.pages.Cluster.Detail.Overview.E5E4E6B5": "请输入",
   "src.pages.Cluster.Detail.Overview.4F7F81B0": "托管状态",

--- a/ui/src/pages/Cluster/Detail/Parameters/index.tsx
+++ b/ui/src/pages/Cluster/Detail/Parameters/index.tsx
@@ -296,11 +296,7 @@ export default function Parameters() {
   ];
 
   return (
-    <PageContainer
-      header={{
-        title: '集群参数',
-      }}
-    >
+    <PageContainer>
       <Row>
         <Col span={24}>
           <Card
@@ -308,7 +304,7 @@ export default function Parameters() {
               <h2 style={{ marginBottom: 0 }}>
                 {intl.formatMessage({
                   id: 'src.pages.Cluster.Detail.Overview.BFE7CA02',
-                  defaultMessage: '集群参数设置',
+                  defaultMessage: '集群参数',
                 })}
               </h2>
             }
@@ -334,7 +330,6 @@ export default function Parameters() {
         initialValues={parametersRecord}
         name={name}
         namespace={ns}
-        // {...(clusterDetail?.info as API.ClusterInfo)}
       />
     </PageContainer>
   );

--- a/ui/src/pages/Cluster/Detail/Parameters/index.tsx
+++ b/ui/src/pages/Cluster/Detail/Parameters/index.tsx
@@ -1,4 +1,5 @@
 import { obcluster } from '@/api';
+import CustomTooltip from '@/components/CustomTooltip';
 import IconTip from '@/components/IconTip';
 import { getClusterDetailReq } from '@/services';
 import { getColumnSearchProps } from '@/utils/component';
@@ -138,11 +139,25 @@ export default function Parameters() {
         defaultMessage: '参数值',
       }),
       dataIndex: 'value',
+      width: 160,
       render: (text: string, record) => {
-        const content =
-          parameters?.find((item) => item.name === record.name)?.value || text;
+        const values = record?.values;
 
-        return <span>{content}</span>;
+        const singleValue = values?.map((item) => item.value);
+        const MultipleValue = values?.map(
+          (item) => `${item.value} {${item.metasStr}}`,
+        );
+        const content = values?.length !== 1 ? MultipleValue : singleValue;
+
+        return (
+          <>
+            {content?.join('') ? (
+              <CustomTooltip text={content} width={150} />
+            ) : (
+              <span>-</span>
+            )}
+          </>
+        );
       },
     },
     {

--- a/ui/src/pages/Cluster/New/Topo.tsx
+++ b/ui/src/pages/Cluster/New/Topo.tsx
@@ -18,6 +18,7 @@ import {
   Space,
 } from 'antd';
 
+import { EFFECT_LIST, OPERATOR_LIST } from '@/constants/node';
 import { RULER_ZONE } from '@/constants/rules';
 import { getNodeLabelsReq } from '@/services';
 import { useAccess } from '@umijs/max';
@@ -50,16 +51,7 @@ export default function Topo({ form }) {
       label: 'DoesNoExist',
     },
   ];
-  const tolerationsOperatorList = [
-    {
-      value: 'Equal',
-      label: 'Equal',
-    },
-    {
-      value: 'Exists',
-      label: 'Exists',
-    },
-  ];
+
   const basicFrom = (topologyConfiguration, name) => (
     <>
       <Col
@@ -129,7 +121,7 @@ export default function Topo({ form }) {
             })}
             options={
               topologyConfiguration === 'Tolerations'
-                ? tolerationsOperatorList
+                ? OPERATOR_LIST
                 : affinitiesOperatorList
             }
           />
@@ -349,20 +341,7 @@ export default function Topo({ form }) {
                           id: 'OBDashboard.components.NodeSelector.PleaseSelect',
                           defaultMessage: '请选择',
                         })}
-                        options={[
-                          {
-                            value: 'NoSchedule',
-                            label: 'NoSchedule',
-                          },
-                          {
-                            value: 'PerferNoSchedule',
-                            label: 'PerferNoSchedule',
-                          },
-                          {
-                            value: 'NoExecute',
-                            label: 'NoExecute',
-                          },
-                        ]}
+                        options={EFFECT_LIST}
                       />
                     </Form.Item>
                   </Col>

--- a/ui/src/pages/Overview/NodesTable.tsx
+++ b/ui/src/pages/Overview/NodesTable.tsx
@@ -127,7 +127,9 @@ export default function NodesTable() {
         ));
 
         const content = text?.map((item) => `${item.key}=${item.value}`);
-        return (
+        return content.length === 0 ? (
+          '-'
+        ) : (
           <CustomTooltip
             text={content}
             tooltipTittle={tooltipTittle}
@@ -154,7 +156,9 @@ export default function NodesTable() {
           ),
         );
 
-        return (
+        return content.length === 0 ? (
+          '-'
+        ) : (
           <CustomTooltip
             text={content}
             tooltipTittle={tooltipTittle}

--- a/ui/src/pages/Overview/NodesTable.tsx
+++ b/ui/src/pages/Overview/NodesTable.tsx
@@ -122,7 +122,7 @@ export default function NodesTable() {
       ellipsis: true,
       width: 160,
       render: (text) => {
-        const tooltipTittle = text?.map((item) => (
+        const tooltipTitle = text?.map((item) => (
           <div>{`${item.key}=${item.value}`}</div>
         ));
 
@@ -132,7 +132,7 @@ export default function NodesTable() {
         ) : (
           <CustomTooltip
             text={content}
-            tooltipTittle={tooltipTittle}
+            tooltipTitle={tooltipTitle}
             width={150}
           />
         );
@@ -148,7 +148,7 @@ export default function NodesTable() {
             ? `${item.key}=${item.value}:${item.effect}`
             : `${item.key}:${item.effect}`,
         );
-        const tooltipTittle = text?.map((item) =>
+        const tooltipTitle = text?.map((item) =>
           item.value ? (
             <div>{`${item.key}=${item.value}:${item.effect}`}</div>
           ) : (
@@ -161,7 +161,7 @@ export default function NodesTable() {
         ) : (
           <CustomTooltip
             text={content}
-            tooltipTittle={tooltipTittle}
+            tooltipTitle={tooltipTitle}
             width={150}
           />
         );

--- a/ui/src/pages/Overview/NodesTable.tsx
+++ b/ui/src/pages/Overview/NodesTable.tsx
@@ -46,7 +46,7 @@ export default function NodesTable() {
   const { data, loading, refresh } = useRequest(getNodeInfoReq);
 
   const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(false);
-  const [nodeRecord, setNodeRecord] = useState<string[]>([]);
+  const [nodeRecord, setNodeRecord] = useState({});
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
   const [batchNodeDrawerOpen, setBatchNodeDrawerOpen] =
     useState<boolean>(false);
@@ -122,9 +122,18 @@ export default function NodesTable() {
       ellipsis: true,
       width: 160,
       render: (text) => {
-        const content = text?.map((item) => `${item.key}=${item.value}`);
+        const tooltipTittle = text?.map((item) => (
+          <div>{`${item.key}=${item.value}`}</div>
+        ));
 
-        return <CustomTooltip text={content} width={150} />;
+        const content = text?.map((item) => `${item.key}=${item.value}`);
+        return (
+          <CustomTooltip
+            text={content}
+            tooltipTittle={tooltipTittle}
+            width={150}
+          />
+        );
       },
     },
     {
@@ -137,8 +146,21 @@ export default function NodesTable() {
             ? `${item.key}=${item.value}:${item.effect}`
             : `${item.key}:${item.effect}`,
         );
+        const tooltipTittle = text?.map((item) =>
+          item.value ? (
+            <div>{`${item.key}=${item.value}:${item.effect}`}</div>
+          ) : (
+            <div>{`${item.key}:${item.effect}`}</div>
+          ),
+        );
 
-        return <CustomTooltip text={content} width={150} />;
+        return (
+          <CustomTooltip
+            text={content}
+            tooltipTittle={tooltipTittle}
+            width={150}
+          />
+        );
       },
     },
     {
@@ -217,8 +239,6 @@ export default function NodesTable() {
         visible={batchNodeDrawerOpen}
         onCancel={() => {
           setBatchNodeDrawerOpen(false);
-          // refresh();
-          // setSelectedRowKeys([]);
         }}
         onSuccess={() => {
           setBatchNodeDrawerOpen(false);
@@ -231,13 +251,14 @@ export default function NodesTable() {
         visible={isDrawerOpen}
         onCancel={() => {
           setIsDrawerOpen(false);
+          setNodeRecord({});
         }}
         onSuccess={() => {
           setIsDrawerOpen(false);
           refresh();
+          setNodeRecord({});
         }}
         nodeRecord={nodeRecord}
-        {...nodeRecord}
       />
     </Col>
   );

--- a/ui/src/pages/Tenant/Detail/Backup/BackupConfiguration.tsx
+++ b/ui/src/pages/Tenant/Detail/Backup/BackupConfiguration.tsx
@@ -93,7 +93,7 @@ export default function BackupConfiguration({
       value: 'bakDataPath',
     },
   ];
-  if (backupPolicy.ossAccessSecret) {
+  if (backupPolicy?.ossAccessSecret) {
     INFO_CONFIG_ARR.splice(2, 0, {
       value: 'ossAccessSecret',
       label: 'OSS Access Secret',
@@ -119,8 +119,8 @@ export default function BackupConfiguration({
     scheduleDates: {
       ...formatBackupPolicyData(backupPolicy),
     },
-    scheduleTime: backupPolicy.scheduleTime
-      ? dayjs(backupPolicy.scheduleTime, 'HH:mm')
+    scheduleTime: backupPolicy?.scheduleTime
+      ? dayjs(backupPolicy?.scheduleTime, 'HH:mm')
       : '',
   };
 
@@ -128,11 +128,11 @@ export default function BackupConfiguration({
     const param = {
       ns,
       name,
-      status: backupPolicy.status === 'PAUSED' ? 'RUNNING' : 'PAUSED',
+      status: backupPolicy?.status === 'PAUSED' ? 'RUNNING' : 'PAUSED',
     };
     const { successful, data } = await editBackupReportWrap(param);
     if (successful) {
-      if (data.status === backupPolicy.status) {
+      if (data.status === backupPolicy?.status) {
         backupPolicyRefresh();
       } else {
         message.success(
@@ -226,13 +226,13 @@ export default function BackupConfiguration({
             </Button>
             <Button
               disabled={
-                backupPolicy.status !== 'RUNNING' &&
-                backupPolicy.status !== 'PAUSED'
+                backupPolicy?.status !== 'RUNNING' &&
+                backupPolicy?.status !== 'PAUSED'
               }
               onClick={changeStatus}
             >
-              {backupPolicy.status === 'PAUSING' ||
-              backupPolicy.status === 'PAUSED'
+              {backupPolicy?.status === 'PAUSING' ||
+              backupPolicy?.status === 'PAUSED'
                 ? intl.formatMessage({
                     id: 'Dashboard.Detail.Backup.BackupConfiguration.Recovery',
                     defaultMessage: '恢复',
@@ -286,9 +286,9 @@ export default function BackupConfiguration({
               </span>
               <Text
                 style={{ width: 316 }}
-                ellipsis={{ tooltip: backupPolicy[infoItem.value] }}
+                ellipsis={{ tooltip: backupPolicy[infoItem?.value] }}
               >
-                {backupPolicy[infoItem.value]}
+                {backupPolicy[infoItem?.value]}
               </Text>
             </Col>
           ))}

--- a/ui/src/pages/Tenant/Detail/Backup/index.tsx
+++ b/ui/src/pages/Tenant/Detail/Backup/index.tsx
@@ -25,7 +25,7 @@ export default function Backup() {
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const [isEditing, setIsEditing] = useState<boolean>(false);
 
-  const [activeTabKey, setActiveTabKey] = useState<string>('recover');
+  const [activeTabKey, setActiveTabKey] = useState<string>('backup');
   const [form] = Form.useForm<FormData>();
   const publicKey = usePublicKey();
   const [clusterList, setClusterList] = useState<API.SimpleClusterList>([]);

--- a/ui/src/pages/Tenant/Detail/NewBackup/RecoverFormItem.tsx
+++ b/ui/src/pages/Tenant/Detail/NewBackup/RecoverFormItem.tsx
@@ -6,7 +6,16 @@ import {
 } from '@/services';
 import { intl } from '@/utils/intl';
 import { useDeepCompareEffect, useRequest, useUpdateEffect } from 'ahooks';
-import { Col, DatePicker, Form, Input, Row, Select, TimePicker } from 'antd';
+import {
+  Button,
+  Col,
+  DatePicker,
+  Form,
+  Input,
+  Row,
+  Select,
+  TimePicker,
+} from 'antd';
 import dayjs from 'dayjs';
 import ResourcePools from '../../New/ResourcePools';
 
@@ -16,6 +25,8 @@ export default function RecoverFormItem({
   selectClusterId,
   setSelectClusterId,
   setClusterList,
+  onFinish,
+  type,
 }) {
   useRequest(getSimpleClusterList, {
     onSuccess: ({ successful, data }) => {
@@ -166,7 +177,7 @@ export default function RecoverFormItem({
       </Col>
       <Col span={8}>
         <Form.Item
-          name={['tenanteName']}
+          name={['tenantName']}
           label={'租户名'}
           rules={[
             {
@@ -198,6 +209,16 @@ export default function RecoverFormItem({
           setClusterList={setClusterList}
         />
       </Col>
+      {type && (
+        <>
+          <Col span={22}></Col>
+          <Col span={2}>
+            <Button type="primary" onClick={() => onFinish()}>
+              提交
+            </Button>
+          </Col>
+        </>
+      )}
     </Row>
   );
 }

--- a/ui/src/pages/Tenant/Detail/NewBackup/RecoverFormItem.tsx
+++ b/ui/src/pages/Tenant/Detail/NewBackup/RecoverFormItem.tsx
@@ -36,7 +36,6 @@ export default function RecoverFormItem({
             zone.checked = false;
           });
         });
-
         setClusterList(data);
       }
     },
@@ -209,7 +208,7 @@ export default function RecoverFormItem({
           setClusterList={setClusterList}
         />
       </Col>
-      {type && (
+      {type === 'detail' && (
         <>
           <Col span={22}></Col>
           <Col span={2}>

--- a/ui/src/pages/Tenant/Detail/NewBackup/index.tsx
+++ b/ui/src/pages/Tenant/Detail/NewBackup/index.tsx
@@ -8,7 +8,7 @@ import { PageContainer } from '@ant-design/pro-components';
 import { useNavigate, useParams } from '@umijs/max';
 import { useRequest } from 'ahooks';
 import { Button, Card, Col, Form, Input, Row, Select, message } from 'antd';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   checkScheduleDatesHaveFull,
   formatBackupForm,
@@ -401,6 +401,11 @@ export default function NewBackup() {
     ),
   };
 
+  useEffect(() => {
+    if (location.search) {
+      setActiveTabKey('recover');
+    }
+  }, []);
   return (
     <PageContainer
       style={{ paddingBottom: 70 }}

--- a/ui/src/pages/Tenant/Detail/NewBackup/index.tsx
+++ b/ui/src/pages/Tenant/Detail/NewBackup/index.tsx
@@ -40,7 +40,7 @@ export default function NewBackup() {
   const scheduleValue = Form.useWatch(['scheduleDates'], form);
   const [clusterList, setClusterList] = useState<API.SimpleClusterList>([]);
   const [selectClusterId, setSelectClusterId] = useState<string>();
-  const [activeTabKey, setActiveTabKey] = useState<string>('recover');
+  const [activeTabKey, setActiveTabKey] = useState<string>('backup');
 
   const distTypes: ParamBackupDestType[] = [
     { label: 'NFS', value: ParamBackupDestType.BackupDestNFS },

--- a/ui/src/pages/Tenant/Detail/Overview/Backups.tsx
+++ b/ui/src/pages/Tenant/Detail/Overview/Backups.tsx
@@ -218,14 +218,6 @@ export default function Backups({
     },
     {
       title: intl.formatMessage({
-        id: 'Dashboard.Detail.Overview.Backups.EncryptionKeySecret',
-        defaultMessage: '加密密钥 Secret',
-      }),
-      dataIndex: 'encryptionSecret',
-      key: 'encryptionSecret',
-    },
-    {
-      title: intl.formatMessage({
         id: 'Dashboard.Detail.Overview.Backups.StartTime',
         defaultMessage: '开始时间',
       }),

--- a/ui/src/pages/Tenant/ZoneItem/index.tsx
+++ b/ui/src/pages/Tenant/ZoneItem/index.tsx
@@ -81,8 +81,12 @@ export default function ZoneItem({
         </Form.Item>
       </Col>
       <Col span={5} style={type === 'tenantBackup' ? { marginTop: 24 } : {}}>
-        <Form.Item name={['pools', name, 'type']} label={'副本类型'}>
-          <Select options={REPLICA_TYPE_LIST} defaultValue={'Full'} />
+        <Form.Item
+          name={['pools', name, 'type']}
+          label={'副本类型'}
+          initialValue={'Full'}
+        >
+          <Select options={REPLICA_TYPE_LIST} />
         </Form.Item>
       </Col>
 

--- a/ui/src/pages/Tenant/ZoneItem/index.tsx
+++ b/ui/src/pages/Tenant/ZoneItem/index.tsx
@@ -32,7 +32,7 @@ export default function ZoneItem({
       ? [{ value: 'Readonly', label: '只读型副本' }]
       : []),
     ...(isGte4_3_3(obversion)
-      ? [{ value: 'Column', label: '只读日志型副本' }]
+      ? [{ value: 'Column', label: '只读列存型副本' }]
       : []),
   ];
 

--- a/ui/src/pages/Tenant/helper.ts
+++ b/ui/src/pages/Tenant/helper.ts
@@ -36,15 +36,16 @@ export function formatNewTenantForm(
         })
         .map((zoneName) => {
           const priority = originFormData[key]?.[zoneName]?.priority;
+          const type = originFormData[key]?.[zoneName]?.type;
           return priority || priority === 0
             ? {
                 zone: zoneName,
                 priority,
-                type: 'Full',
+                type,
               }
             : {
                 zone: zoneName,
-                type: 'Full',
+                type,
               };
         });
     } else if (key === 'source') {

--- a/ui/src/services/tenant.ts
+++ b/ui/src/services/tenant.ts
@@ -47,6 +47,7 @@ export async function getTenant({
     'primaryZone',
     'deletionProtection',
     'rootCredential',
+    'scenario',
   ];
   const res: API.TenantBasicInfo = {
     info: {},


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
问题：
1. 创建租户页面，副本类型应该是全能型副本，只读型副本和只读列存型副本
2. 创建租户，指定副本类型不生效，请求参数仍然都是 Full 类型的
3. 点创建备份策略之后应该跳转到备份的 tab 直接去配置备份策略，现在跳转的是恢复的 tab，备份策略提交了之后目前也跳转到了恢复的 tab
4. 恢复页面下方不要放备份相关的东西
5. 租户恢复表单的提交按钮放在下面
6. 租户备份，提交的信息应包含备份策略信息及租户基础信息
7. 集群参数值未显示
8. node列表， node 的 label 和 taints需要每组数据分行展示
9. 编辑过节点提交之后要刷新一下节点信息，测试时发现更新成功了，但是前端再次点编辑的时候，列表中没有更新过的 label，刷新页面后才可以
10.   Effect 中拼写错误应该是 PreferNoSchedule 而不是 PerferNoSchedule
11. 批量编辑 node 的 label 和 taints ，默认可以展示一行，不需要原值--- keys 支持模糊搜索，勾选中查找。默认可以展示一行

<img width="1424" alt="image" src="https://github.com/user-attachments/assets/a1dea1a8-ca67-41b6-b8ac-4bca7d313c93" />
<img width="877" alt="image" src="https://github.com/user-attachments/assets/921126c4-2e86-49ac-bee7-b0827693cbd5" />
<img width="790" alt="image" src="https://github.com/user-attachments/assets/c4836b2a-2ad3-4ca2-92d1-af58ab24ce57" />
<img width="860" alt="image" src="https://github.com/user-attachments/assets/aada0cef-964e-446f-acc7-8285ea916b06" />
<img width="798" alt="image" src="https://github.com/user-attachments/assets/1b16d786-9fd3-4235-b455-c80c1b31c502" />
<img width="824" alt="image" src="https://github.com/user-attachments/assets/735f270d-ecca-4c75-a925-6cfb5a3997d0" />
<img width="1251" alt="image" src="https://github.com/user-attachments/assets/beb48f05-3f4c-41e1-aade-41947ef9e6d6" />

<img width="1209" alt="image" src="https://github.com/user-attachments/assets/8aacd205-7f6b-422f-8c66-c15b4827caf3" />
<img width="1434" alt="image" src="https://github.com/user-attachments/assets/9cb7a91c-bc5d-45d8-8fa0-82c900467b4e" />
<img width="1405" alt="image" src="https://github.com/user-attachments/assets/7779d22e-606d-4731-8230-d4ac0291ad6d" />
<img width="1427" alt="image" src="https://github.com/user-attachments/assets/a1d57507-b644-4bd1-afac-c97b06757173" />


## Solution Description
<!-- Please clearly and concisely describe your solution. -->



<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
<!--
Thank you for contributing to OceanBase!
Please feel free to ping the maintainers for the review!
-->

## Summary
<!--
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
question:
1. Create a tenant page, the replica type should be an all-round replica, read-only replica and read-only column-storage replica
2. Create a tenant, the specified replica type does not take effect, and the request parameters are still of the Full type
3. After clicking to create the backup policy, you should jump to the backup tab. Directly configure the backup policy. Now the recovery tab is redirected. After the backup policy is submitted, it is also redirected to the recovery tab.
4. Do not put backup-related things at the bottom of the recovery page
5. The submission button for the tenant recovery form is placed below
6. For tenant backup, the submitted information should include backup policy information and tenant basic information.
7. The cluster parameter value is not displayed
8. The node list, the node's label and tains need to be displayed in each set of data branches.
9. After editing the node submission, you need to refresh the node information. During the test, you found that the update was successful. However, when the front-end clicked edit again, there was no updated label in the list, and you can only refresh the page.
10. The spelling error in Effect should be PreferNoSchedule instead of PerferNoSchedule
11. Bulk edits the label and taints of nodes, and can display a line by default, without the original value--- keys supports fuzzy search, check search. A line can be displayed by default

<img width="1424" alt="image" src="https://github.com/user-attachments/assets/a1dea1a8-ca67-41b6-b8ac-4bca7d313c93" />
<img width="877" alt="image" src="https://github.com/user-attachments/assets/921126c4-2e86-49ac-bee7-b0827693cbd5" />
<img width="790" alt="image" src="https://github.com/user-attachments/assets/c4836b2a-2ad3-4ca2-92d1-af58ab24ce57" />
<img width="860" alt="image" src="https://github.com/user-attachments/assets/aada0cef-964e-446f-acc7-8285ea916b06" />
<img width="798" alt="image" src="https://github.com/user-attachments/assets/1b16d786-9fd3-4235-b455-c80c1b31c502" />
<img width="824" alt="image" src="https://github.com/user-attachments/assets/735f270d-ecca-4c75-a925-6cfb5a3997d0" />
<img width="1251" alt="image" src="https://github.com/user-attachments/assets/beb48f05-3f4c-41e1-aade-41947ef9e6d6" />

<img width="1209" alt="image" src="https://github.com/user-attachments/assets/8aacd205-7f6b-422f-8c66-c15b4827caf3" />
<img width="1434" alt="image" src="https://github.com/user-attachments/assets/9cb7a91c-bc5d-45d8-8fa0-82c900467b4e" />
<img width="1405" alt="image" src="https://github.com/user-attachments/assets/7779d22e-606d-4731-8230-d4ac0291ad6d" />
<img width="1427" alt="image" src="https://github.com/user-attachments/assets/a1d57507-b644-4bd1-afac-c97b06757173" />


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
