### PR TITLE
change default retry count before bootstrap

### DIFF
--- a/internal/const/oceanbase/time.go
+++ b/internal/const/oceanbase/time.go
@@ -25,7 +25,7 @@ const (
 const (
 	ProbeCheckPeriodSeconds = 2
 	ProbeCheckDelaySeconds  = 5
-	GetConnectionMaxRetries = 10
+	GetConnectionMaxRetries = 100
 	CheckConnectionInterval = 3
 	CheckJobInterval        = 3
 	CheckJobMaxRetries      = 100


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Change default retry count for getting connection before bootstrap, the wait time is now 3 * 100 =300 seconds, it should be able to handle oceanbase cluster with large or slow disk.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
