### PR TITLE
set annotation after add obzones

### DIFF
--- a/internal/resource/obcluster/obcluster_flow.go
+++ b/internal/resource/obcluster/obcluster_flow.go
@@ -94,6 +94,7 @@ func genAddOBZoneFlow(_ *OBClusterManager) *tasktypes.TaskFlow {
 				tCreateOBZone,
 				tWaitOBZoneRunning,
 				tModifySysTenantReplica,
+				tAnnotateOBCluster,
 			},
 			TargetStatus: clusterstatus.Running,
 		},


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
fix #873 
add a step to set annotations after scale zones
<img width="838" height="146" alt="image" src="https://github.com/user-attachments/assets/fdc25c0f-6687-474a-85ff-74eafd6eb223" />
<img width="1486" height="182" alt="image" src="https://github.com/user-attachments/assets/abe72a34-8dea-49d2-945a-e1ebc16b99e1" />
The observer is successfully triggered to scale vertically in the newly added obzone.

## Solution Description
<!-- Please clearly and concisely describe your solution. -->
